### PR TITLE
Spinlock mm ramfile

### DIFF
--- a/include/sdsl/memory_management.hpp
+++ b/include/sdsl/memory_management.hpp
@@ -10,16 +10,7 @@
 #include <map>
 #include <iostream>
 #include <cstdlib>
-
-
-#ifndef SDSL_MULTI_THREAD
-#define SDSL_MULTI_THREAD
-#endif
-
-
-#ifdef SDSL_MULTI_THREAD
 #include <mutex>
-#endif
 
 namespace sdsl
 {
@@ -115,19 +106,14 @@ class mm
         static uint64_t m_granularity;
         static uint64_t m_pre_max_mem;
         static uint64_t m_pre_rtime;
-
-#ifdef SDSL_MULTI_THREAD
         static util::spin_lock m_spinlock;
-#endif
 
     public:
         mm();
 
         template<class int_vec_t>
         static void add(int_vec_t* v, bool moved=false) {
-#ifdef SDSL_MULTI_THREAD
             std::lock_guard<util::spin_lock> lock(m_spinlock);
-#endif
             if (mm::m_items.find((uint64_t)v) == mm::m_items.end()) {
                 mm_item_base* item = new mm_item<int_vec_t>(v);
                 if (false and util::verbose) {
@@ -173,9 +159,7 @@ class mm
             if (old_size != ((v.m_size+63)>>6)<<3) {
                 log("");
                 {
-#ifdef SDSL_MULTI_THREAD
                     std::lock_guard<util::spin_lock> lock(m_spinlock);
-#endif
                     m_total_memory -= old_size; // subtract old space
                     m_total_memory += ((v.m_size+63)>>6)<<3; // add new space
                 }
@@ -185,9 +169,7 @@ class mm
 
         template<class int_vec_t>
         static void remove(int_vec_t* v) {
-#ifdef SDSL_MULTI_THREAD
             std::lock_guard<util::spin_lock> lock(m_spinlock);
-#endif
             if (mm::m_items.find((uint64_t)v) != mm::m_items.end()) {
                 if (false and util::verbose) {
                     std::cout << "mm:remove: remove vector " << v << std::endl;

--- a/include/sdsl/ram_fs.hpp
+++ b/include/sdsl/ram_fs.hpp
@@ -9,15 +9,7 @@
 #include <string>
 #include <map>
 #include <vector>
-
-#ifndef SDSL_MULTI_THREAD
-#define SDSL_MULTI_THREAD
-#endif
-
-
-#ifdef SDSL_MULTI_THREAD
 #include <mutex>
-#endif
 
 namespace sdsl
 {
@@ -52,9 +44,7 @@ class ram_fs
         friend class ram_fs_initializer;
         typedef std::map<std::string, content_type> mss_type;
         static mss_type m_map;
-#ifdef SDSL_MULTI_THREAD
         static std::recursive_mutex m_rlock;
-#endif
 
     public:
         //! Default construct

--- a/include/sdsl/util.hpp
+++ b/include/sdsl/util.hpp
@@ -45,14 +45,8 @@
 #include <numeric>
 #include <random>
 #include <chrono>
-
-
-#ifdef SDSL_MULTI_THREAD
 #include <atomic>
 #include <mutex>
-#include <thread>
-#endif
-
 
 // macros to transform a defined name to a string
 #define SDSL_STR(x) #x
@@ -376,7 +370,6 @@ class stop_watch
         uint64_t abs_page_faults();
 };
 
-#ifdef SDSL_MULTI_THREAD
 class spin_lock
 {
     private:
@@ -391,8 +384,6 @@ class spin_lock
             m_slock.clear(std::memory_order_release);
         };
 };
-#endif // end SDSL_MULTI_THREAD
-
 
 
 } // end namespace util

--- a/lib/memory_management.cpp
+++ b/lib/memory_management.cpp
@@ -20,10 +20,7 @@ uint64_t sdsl::mm::m_granularity;
 uint64_t sdsl::mm::m_pre_rtime;
 uint64_t sdsl::mm::m_pre_max_mem;
 
-#ifdef SDSL_MULTI_THREAD
 sdsl::util::spin_lock sdsl::mm::m_spinlock;
-#endif
-
 
 sdsl::mm_initializer::mm_initializer()
 {
@@ -54,9 +51,6 @@ namespace sdsl
 bool mm::map_hp()
 {
 #ifdef MAP_HUGETLB
-#ifdef SDSL_MULTI_THREAD
-    std::lock_guard<util::spin_lock> lock(m_spinlock);
-#endif
     size_t hpgs= (m_total_memory+HUGE_LEN-1)/HUGE_LEN; // number of huge pages required to store the int_vectors
     m_data = (uint64_t*)mmap(NULL, hpgs*HUGE_LEN, HUGE_PROTECTION, HUGE_FLAGS, 0, 0);
     if (m_data == MAP_FAILED) {
@@ -78,9 +72,6 @@ bool mm::map_hp()
 bool mm::unmap_hp()
 {
 #ifdef MAP_HUGETLB
-#ifdef SDSL_MULTI_THREAD
-    std::lock_guard<util::spin_lock> lock(m_spinlock);
-#endif
     size_t hpgs= (m_total_memory+HUGE_LEN-1)/HUGE_LEN; // number of huge pages
     bool success = true;
     for (tMVecItem::const_iterator it=m_items.begin(); it!=m_items.end(); ++it) {
@@ -101,17 +92,13 @@ bool mm::unmap_hp()
 
 void mm::log_stream(std::ostream* out)
 {
-#ifdef SDSL_MULTI_THREAD
     std::lock_guard<util::spin_lock> lock(m_spinlock);
-#endif
     m_out = out;
 }
 
 void mm::log_granularity(uint64_t granularity)
 {
-#ifdef SDSL_MULTI_THREAD
     std::lock_guard<util::spin_lock> lock(m_spinlock);
-#endif
     m_granularity = granularity;
 }
 

--- a/lib/ram_fs.cpp
+++ b/lib/ram_fs.cpp
@@ -7,10 +7,8 @@
 static int nifty_counter = 0;
 
 sdsl::ram_fs::mss_type sdsl::ram_fs::m_map;
-
-#ifdef SDSL_MULTI_THREAD
 std::recursive_mutex sdsl::ram_fs::m_rlock;
-#endif
+
 
 sdsl::ram_fs_initializer::ram_fs_initializer()
 {
@@ -34,9 +32,7 @@ ram_fs::ram_fs() {};
 void
 ram_fs::store(const std::string& name, content_type data)
 {
-#ifdef SDSL_MULTI_THREAD
     std::lock_guard<std::recursive_mutex> lock(m_rlock);
-#endif
     if (!exists(name)) {
         std::string cname = name;
         m_map.insert(std::make_pair(std::move(cname), std::move(data)));
@@ -48,27 +44,21 @@ ram_fs::store(const std::string& name, content_type data)
 bool
 ram_fs::exists(const std::string& name)
 {
-#ifdef SDSL_MULTI_THREAD
     std::lock_guard<std::recursive_mutex> lock(m_rlock);
-#endif
     return m_map.find(name) != m_map.end();
 }
 
 ram_fs::content_type&
 ram_fs::content(const std::string& name)
 {
-#ifdef SDSL_MULTI_THREAD
     std::lock_guard<std::recursive_mutex> lock(m_rlock);
-#endif
     return m_map[name];
 }
 
 size_t
 ram_fs::file_size(const std::string& name)
 {
-#ifdef SDSL_MULTI_THREAD
     std::lock_guard<std::recursive_mutex> lock(m_rlock);
-#endif
     if (exists(name)) {
         return m_map[name].size();
     } else {
@@ -79,9 +69,7 @@ ram_fs::file_size(const std::string& name)
 int
 ram_fs::remove(const std::string& name)
 {
-#ifdef SDSL_MULTI_THREAD
     std::lock_guard<std::recursive_mutex> lock(m_rlock);
-#endif
     m_map.erase(name);
     return 0;
 }
@@ -89,9 +77,7 @@ ram_fs::remove(const std::string& name)
 int
 ram_fs::rename(const std::string old_filename, const std::string new_filename)
 {
-#ifdef SDSL_MULTI_THREAD
     std::lock_guard<std::recursive_mutex> lock(m_rlock);
-#endif
     m_map[new_filename] = std::move(m_map[old_filename]);
     remove(old_filename);
     return 0;


### PR DESCRIPTION
use spinlocks to protect the memory management and ram_fs global structures. note: needs testing on clang
