### PR TITLE
Generalized output for vectors/bitvectors

### DIFF
--- a/include/sdsl/bit_vector_il.hpp
+++ b/include/sdsl/bit_vector_il.hpp
@@ -24,6 +24,7 @@
 
 #include "int_vector.hpp"
 #include "util.hpp"
+#include "iterators.hpp"
 
 #include <queue>
 
@@ -60,8 +61,11 @@ class bit_vector_il
         static_assert(t_bs >= 64 , "bit_vector_il: blocksize must be be at least 64 bits.");
         static_assert(power_of_two(t_bs), "bit_vector_il: blocksize must be a power of two.");
     public:
-        typedef bit_vector::size_type   size_type;
-        typedef size_type               value_type;
+        typedef bit_vector::size_type                       size_type;
+        typedef size_type                                   value_type;
+        typedef bit_vector::difference_type                 difference_type;
+        typedef random_access_const_iterator<bit_vector_il> iterator;
+        typedef bv_tag                                      index_category;
 
         friend class rank_support_il<1,t_bs>;
         friend class rank_support_il<0,t_bs>;
@@ -202,6 +206,14 @@ class bit_vector_il
                 m_data.swap(bv.m_data);
                 m_rank_samples.swap(bv.m_rank_samples);
             }
+        }
+
+        iterator begin() const {
+            return iterator(this, 0);
+        }
+
+        iterator end() const {
+            return iterator(this, size());
         }
 };
 

--- a/include/sdsl/enc_vector.hpp
+++ b/include/sdsl/enc_vector.hpp
@@ -72,6 +72,7 @@ class enc_vector
         typedef int_vector<>::size_type                  size_type;
         typedef t_coder                                  coder;
         typedef typename enc_vector_trait<t_width>::int_vector_type int_vector_type;
+        typedef iv_tag                                   index_category;
         static  const uint32_t                           sample_dens    = t_dens;
 
         int_vector<0>     m_z;                       // storage for encoded deltas

--- a/include/sdsl/int_vector.hpp
+++ b/include/sdsl/int_vector.hpp
@@ -110,6 +110,16 @@ class elias_delta;
 class char_array_serialize_wrapper;
 
 template<uint8_t t_width>
+struct int_vec_category_trait {
+    typedef iv_tag type;
+};
+
+template<>
+struct int_vec_category_trait<1> {
+    typedef bv_tag type;
+};
+
+template<uint8_t t_width>
 struct int_vector_trait {
     typedef uint64_t                                    value_type;
     typedef int_vector<t_width>                         int_vector_type;
@@ -259,6 +269,7 @@ class int_vector
         typedef rank_support_v<0,1>                                 rank_0_type;
         typedef select_support_mcl<1,1>                             select_1_type;
         typedef select_support_mcl<0,1>                             select_0_type;
+        typedef typename int_vec_category_trait<t_width>::type      index_category;
 
         friend struct int_vector_trait<t_width>;
         friend class  int_vector_iterator_base<int_vector>;
@@ -1078,16 +1089,20 @@ operator+(typename int_vector_const_iterator<t_int_vector>::difference_type n,
     return it + n;
 }
 
-inline std::ostream& operator<<(std::ostream& os, const int_vector<1>& v)
+template<class t_bv>
+inline typename std::enable_if<std::is_same<typename t_bv::index_category ,bv_tag>::value, std::ostream&>::type
+operator<<(std::ostream& os, const t_bv& bv)
 {
-    for (auto it=v.begin(), end = v.end(); it != end; ++it) {
-        os << *it;
+    for (auto b : bv) {
+        os << b;
     }
     return os;
 }
 
-template<uint8_t t_width>
-inline std::ostream& operator<<(std::ostream& os, const int_vector<t_width>& v)
+
+template<class t_iv>
+inline typename std::enable_if<std::is_same<typename t_iv::index_category ,iv_tag>::value, std::ostream&>::type
+operator<<(std::ostream& os, const t_iv& v)
 {
     for (auto it=v.begin(), end = v.end(); it != end; ++it) {
         os << *it;

--- a/include/sdsl/rrr_vector.hpp
+++ b/include/sdsl/rrr_vector.hpp
@@ -25,6 +25,7 @@
 #include "int_vector.hpp"
 #include "util.hpp"
 #include "rrr_helper.hpp" // for binomial helper class
+#include "iterators.hpp"
 #include <vector>
 #include <algorithm> // for next_permutation
 #include <iostream>
@@ -73,9 +74,12 @@ class rrr_vector
     private:
         static_assert(t_bs >= 3 and t_bs <= 256 , "rrr_vector: block size t_bs must be 3 <= t_bs <= 256.");
     public:
-        typedef bit_vector::size_type  size_type;
-        typedef bit_vector::value_type value_type;
-        typedef t_rac                  rac_type;
+        typedef bit_vector::size_type                    size_type;
+        typedef bit_vector::value_type                   value_type;
+        typedef bit_vector::difference_type              difference_type;
+        typedef t_rac                                    rac_type;
+        typedef random_access_const_iterator<rrr_vector> iterator;
+        typedef bv_tag                                   index_category;
 
         typedef rank_support_rrr<1, t_bs, t_rac>   rank_1_type;
         typedef rank_support_rrr<0, t_bs, t_rac>   rank_0_type;
@@ -134,7 +138,7 @@ class rrr_vector
         //! Constructor
         /*!
         *  \param bv  Uncompressed bitvector.
-        *  \param k Store rank samples and pointers each k-th blocks.
+        *  \param k   Store rank samples and pointers each k-th blocks.
         */
         rrr_vector(const bit_vector& bv, uint16_t k=32): m_k(k) {
             m_size = bv.size();
@@ -311,6 +315,14 @@ class rrr_vector
             m_btnrp.load(in);
             m_rank.load(in);
             m_invert.load(in);
+        }
+
+        iterator begin() const {
+            return iterator(this, 0);
+        }
+
+        iterator end() const {
+            return iterator(this, size());
         }
 };
 

--- a/include/sdsl/rrr_vector_15.hpp
+++ b/include/sdsl/rrr_vector_15.hpp
@@ -26,6 +26,7 @@
 #include "util.hpp"
 #include "rrr_helper.hpp" // for binomial helper class
 #include "rrr_vector.hpp"
+#include "iterators.hpp"
 #include <vector>
 #include <algorithm> // for next_permutation
 #include <iostream>
@@ -123,9 +124,12 @@ template<class t_rac>
 class rrr_vector<15, t_rac>
 {
     public:
-        typedef bit_vector::size_type size_type;
-        typedef bit_vector::value_type value_type;
-        typedef t_rac                  rac_type;
+        typedef bit_vector::size_type                    size_type;
+        typedef bit_vector::value_type                   value_type;
+        typedef bit_vector::difference_type              difference_type;
+        typedef t_rac                                    rac_type;
+        typedef random_access_const_iterator<rrr_vector> iterator;
+        typedef bv_tag                                   index_category;
 
         friend class rank_support_rrr<0, 15, t_rac>;
         friend class rank_support_rrr<1, 15, t_rac>;
@@ -334,6 +338,14 @@ class rrr_vector<15, t_rac>
             m_btnr.load(in);
             m_btnrp.load(in);
             m_rank.load(in);
+        }
+
+        iterator begin() const {
+            return iterator(this, 0);
+        }
+
+        iterator end() const {
+            return iterator(this, size());
         }
 };
 

--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -25,6 +25,7 @@
 #include "int_vector.hpp"
 #include "select_support_mcl.hpp"
 #include "util.hpp"
+#include "iterators.hpp"
 
 //! Namespace for the succinct data structure library
 namespace sdsl
@@ -68,10 +69,13 @@ template<class t_hi_bit_vector = bit_vector,
 class sd_vector
 {
     public:
-        typedef bit_vector::size_type size_type;
-        typedef size_type value_type;
-        typedef t_select_0 select_0_support_type;
-        typedef t_select_1 select_1_support_type;
+        typedef bit_vector::size_type                   size_type;
+        typedef size_type                               value_type;
+        typedef bit_vector::difference_type             difference_type;
+        typedef random_access_const_iterator<sd_vector> iterator;
+        typedef bv_tag                                  index_category;
+        typedef t_select_0                              select_0_support_type;
+        typedef t_select_1                              select_1_support_type;
 
         friend class rank_support_sd<t_hi_bit_vector, select_1_support_type, select_0_support_type>;
         friend class select_support_sd<t_hi_bit_vector, select_1_support_type, select_0_support_type>;
@@ -221,6 +225,14 @@ class sd_vector
             m_high.load(in);
             m_high_1_select.load(in, &m_high);
             m_high_0_select.load(in, &m_high);
+        }
+
+        iterator begin() const {
+            return iterator(this, 0);
+        }
+
+        iterator end() const {
+            return iterator(this, size());
         }
 };
 

--- a/include/sdsl/sdsl_concepts.hpp
+++ b/include/sdsl/sdsl_concepts.hpp
@@ -26,6 +26,9 @@
 namespace sdsl
 {
 
+struct bv_tag {}; // bitvector tag
+struct iv_tag {}; // int_vector tag
+
 struct csa_tag {}; // compressed suffix array (CSAs) tag
 struct cst_tag {}; // compressed suffix tree (CST) tag
 struct wt_tag {};  // wavelet tree tag

--- a/include/sdsl/vlc_vector.hpp
+++ b/include/sdsl/vlc_vector.hpp
@@ -63,6 +63,7 @@ class vlc_vector
         typedef ptrdiff_t                                difference_type;
         typedef int_vector<>::size_type                  size_type;
         typedef t_coder                                  coder;
+        typedef iv_tag                                   index_category;
         typedef typename
         vlc_vector_trait<t_width>::int_vector_type      int_vector_type;
 


### PR DESCRIPTION
Now it's also possible to output the contents
of compressed bitvectors and intvectors like
that:

rrr_vector<> bv = bit_vector{1,0,1,0,0,1,0};
cout << bv << endl;

enc_vector<> ev = int_vector<>{1,2,3,4,5,6,7,9};
cout << ev << endl;
