### PR TITLE
increased log granularity to 20ms to decrease the size of visualization

### DIFF
--- a/include/sdsl/memory_management.hpp
+++ b/include/sdsl/memory_management.hpp
@@ -82,7 +82,7 @@ class memory_monitor
                 }
             }
         };
-        std::chrono::milliseconds log_granularity = std::chrono::milliseconds(1);
+        std::chrono::milliseconds log_granularity = std::chrono::milliseconds(20);
         int64_t current_usage = 0;
         bool track_usage = false;
         std::vector<mm_event> completed_events;


### PR DESCRIPTION
currently the default log granularity is 1ms. this causes log files to be too large. this increases the granularity to 20ms which should still show all important events while decreasing the size of the html file.
