### PR TITLE
Addressed issue #158

### DIFF
--- a/examples/node_iterator.cpp
+++ b/examples/node_iterator.cpp
@@ -1,0 +1,39 @@
+#include <sdsl/suffix_trees.hpp>
+#include <iostream>
+
+using namespace sdsl;
+using namespace std;
+
+template<class t_cst>
+void output_node(const typename t_cst::node_type& v, const t_cst& cst)
+{
+    cout << cst.depth(v) << "-[" << cst.lb(v) << ","
+         << cst.rb(v) << "]" << endl;
+}
+
+template<class t_cst>
+void run()
+{
+    t_cst cst;
+    construct_im(cst, "ananas", 1);
+    for (auto v : cst) {
+        output_node(v, cst);
+    }
+    cout<<"--"<<endl;
+    auto v = cst.select_leaf(2);
+    for (auto it = cst.begin(v); it != cst.end(v); ++it) {
+        output_node(*it, cst);
+    }
+    cout<<"--"<<endl;
+    v = cst.parent(cst.select_leaf(4));
+    for (auto it = cst.begin(v); it != cst.end(v); ++it) {
+        output_node(*it, cst);
+    }
+    cout<<"---"<<endl;
+}
+
+int main()
+{
+    run<cst_sct3<>>();
+    run<cst_sada<>>();
+}

--- a/include/sdsl/cst_sada.hpp
+++ b/include/sdsl/cst_sada.hpp
@@ -238,12 +238,26 @@ class cst_sada
             return const_iterator(this, root(), false, true);
         }
 
+        //! Returns a const_iterator to the first element of a depth first traversal of the subtree rooted at node v.
+        const_iterator begin(const node_type& v)const {
+            if (0 == m_bp.size() and root()==v)
+                return end();
+            return const_iterator(this, v, false, true);
+        }
+
 //! Returns a const_iterator to the element after the last element.
         /*! Required for the STL Container Concept.
          *  \sa begin.
          */
         const_iterator end()const {
             return const_iterator(this, root(), true, false);
+        }
+
+        //! Returns a const_iterator to the element past the end of a depth first traversal of the subtree rooted at node v.
+        const_iterator end(const node_type& v)const {
+            if (root() == v)
+                return end();
+            return ++const_iterator(this, v, true, true);
         }
 
 //! Returns an iterator to the first element of a bottom-up traversal of the tree.

--- a/include/sdsl/cst_sct3.hpp
+++ b/include/sdsl/cst_sct3.hpp
@@ -397,11 +397,15 @@ class cst_sct3
         const_iterator begin()const {
             if (0 == m_bp.size())  // special case: tree is uninitialized
                 return end();
-//            else if (2 == m_bp.size()) { // special case: the root is a leaf
-//                return const_iterator(this, root(), true, true);
-//            }
             return const_iterator(this, root(), false, true);
         };
+
+        //! Returns a const_iterator to the first element of a depth first traversal of the subtree rooted at node v.
+        const_iterator begin(const node_type& v)const {
+            if (0 == m_bp.size() and root()==v)
+                return end();
+            return const_iterator(this, v, false, true);
+        }
 
         //! Returns a const_iterator to the element after the last element of a depth first traversal of the tree.
         /*! Required for the STL Container Concept.
@@ -409,6 +413,13 @@ class cst_sct3
          */
         const_iterator end()const {
             return const_iterator(this, root(), true, false);
+        }
+
+        //! Returns a const_iterator to the element past the end of a depth first traversal of the subtree rooted at node v.
+        const_iterator end(const node_type& v)const {
+            if (root() == v)
+                return end();
+            return ++const_iterator(this, v, true, true);
         }
 
         //! Returns an iterator to the first element of a bottom-up traversal of the tree.


### PR DESCRIPTION
Added subtree iterators `begin(v)`, `end(v)` to CSTs.
