### PR TITLE
check input ranges in rest-unique-range-values

### DIFF
--- a/include/sdsl/wt_algorithm.hpp
+++ b/include/sdsl/wt_algorithm.hpp
@@ -510,8 +510,19 @@ restricted_unique_range_values(const t_wt& wt,
 
     std::vector<typename t_wt::value_type> unique_values;
 
+    // make sure things are within bounds
+    if( x_j > wt.size()-1 ) x_j = wt.size()-1;
+    if( (x_i > x_j) || (y_i > y_j) ) { 
+        return unique_values;
+    }
     auto lower_y_bound = symbol_gte(wt,y_i);
     auto upper_y_bound = symbol_lte(wt,y_j);
+    // is the y range valid?
+    if( !lower_y_bound.first || !upper_y_bound.first 
+        || (lower_y_bound.second > upper_y_bound.second) )  {
+        return unique_values;
+    }
+
     auto lower_y_bound_path = wt.path(lower_y_bound.second);
     auto upper_y_bound_path = wt.path(upper_y_bound.second);
 

--- a/test/WtIntTest.cpp
+++ b/test/WtIntTest.cpp
@@ -749,6 +749,20 @@ test_range_unique_values(typename enable_if<t_wt::lex_ordered, t_wt>::type& wt)
             itr++;
         }
     }
+
+    // check invalid queries don't do the wrong thing
+    //                0 1 2 3 4 5  6  7  8  9  10
+    int_vector<> S = {5,6,7,8,9,5,6,7,13,14,15};
+    t_wt wt_test;
+    construct_im(wt_test,S);
+    auto empty_uniq_values = restricted_unique_range_values(wt,8,3,7,9);
+    ASSERT_TRUE(empty_uniq_values.size() == 0);
+    empty_uniq_values = restricted_unique_range_values(wt,3,8,9,7);
+    ASSERT_TRUE(empty_uniq_values.size() == 0);
+    empty_uniq_values = restricted_unique_range_values(wt,3,8,3,4);
+    ASSERT_TRUE(empty_uniq_values.size() == 0);
+    empty_uniq_values = restricted_unique_range_values(wt,3,8,10,11);
+    ASSERT_TRUE(empty_uniq_values.size() == 0);
 }
 
 //! Test the load method and intersect


### PR DESCRIPTION
the ranges passed into restricted_unique_range_values could potentially
be invalid which can lead to unexpected results. this commit adds sanity
checks at the beginning of the call to make sure this does not happen.
