### PR TITLE
Renaming bug fix

### DIFF
--- a/include/sdsl/cst_iterators.hpp
+++ b/include/sdsl/cst_iterators.hpp
@@ -218,7 +218,7 @@ class cst_bottom_up_const_forward_iterator: public std::iterator<std::forward_it
             if (w == m_cst->root()) {   // if no next right sibling exist
                 m_v = m_cst->parent(m_v);    // go to parent
             } else { // if next right sibling exist
-                m_v = m_cst->leftmost_leaf_in_the_subtree(w);   // go to leaftmost leaf in the subtree of w
+                m_v = m_cst->leftmost_leaf(w);   // go to leaftmost leaf in the subtree of w
             }
             return *this;
         }

--- a/include/sdsl/cst_sada.hpp
+++ b/include/sdsl/cst_sada.hpp
@@ -264,7 +264,7 @@ class cst_sada
         const_bottom_up_iterator begin_bottom_up()const {
             if (0 == m_bp.size())  // special case: tree is uninitialized
                 return end_bottom_up();
-            return const_bottom_up_iterator(this, leftmost_leaf_in_the_subtree(root()));
+            return const_bottom_up_iterator(this, leftmost_leaf(root()));
         }
 
 //! Returns an iterator to the element after the last element of a bottom-up traversal of the tree.


### PR DESCRIPTION
```
leftmost_leaf_in_the_subtree
```

is renamed to

```
leftmost_leaf
```

which is what is used by cst_*.
