### PR TITLE
Test rank_0 for sd_vector 

### DIFF
--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -1,5 +1,5 @@
 /* sdsl - succinct data structures library
-    Copyright (C) 2012-2013 Simon Gog
+    Copyright (C) 2012-2014 Simon Gog
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -357,12 +357,12 @@ class rank_support_sd
             size_type sel_high = m_v->high_0_select(high_val + 1);
             size_type rank_low = sel_high - high_val; //
             if (0 == rank_low)
-                return 0;
+                return rank_support_sd_trait<t_b>::adjust_rank(0, i);
             size_type val_low = i & bits::lo_set[ m_v->wl ];
             // now since rank_low > 0 => sel_high > 0
             do {
                 if (!sel_high)
-                    return 0;
+                    return rank_support_sd_trait<t_b>::adjust_rank(0, i);
                 --sel_high; --rank_low;
             } while (m_v->high[sel_high] and m_v->low[rank_low] >= val_low);
             return rank_support_sd_trait<t_b>::adjust_rank(rank_low+1, i);
@@ -475,9 +475,9 @@ class select_support_sd
             m_v = v;
         }
 
-        select_support_sd& operator=(const select_support_sd& rs) {
-            if (this != &rs) {
-                set_vector(rs.m_v);
+        select_support_sd& operator=(const select_support_sd& ss) {
+            if (this != &ss) {
+                set_vector(ss.m_v);
             }
             return *this;
         }

--- a/test/RankSupportTest.cpp
+++ b/test/RankSupportTest.cpp
@@ -33,7 +33,7 @@ typedef Types<rank_support_il<1, 256>,
         rank_support_rrr<1, 127>,
         rank_support_rrr<1, 128>,
         rank_support_rrr<1, 129>,
-        rank_support_sd<>,
+        rank_support_sd<1>,
         rank_support_il<0, 256>,
         rank_support_il<0, 512>,
         rank_support_il<0, 1024>,
@@ -51,7 +51,7 @@ typedef Types<rank_support_il<1, 256>,
         rank_support_rrr<0, 127>,
         rank_support_rrr<0, 128>,
         rank_support_rrr<0, 129>,
-        rank_support_sd<1>
+        rank_support_sd<0>
         > Implementations;
 
 TYPED_TEST_CASE(RankSupportTest, Implementations);


### PR DESCRIPTION
Bug fix sd_vector rank_0 queries at the start of the bitvector
