### PR TITLE
fix issue #202 and introduce more type safety

### DIFF
--- a/examples/int-vector-mapper.cpp
+++ b/examples/int-vector-mapper.cpp
@@ -36,9 +36,9 @@ int main(int argc, char* argv[])
         store_to_file(iv,tmp_file);
     }
 
-    // (2) memory map the content of tmp_file
+    // (2) open readonly! memory map the content of tmp_file
     {
-        int_vector_mapper<> ivm(tmp_file);
+        const int_vector_mapper<0,std::ios_base::in> ivm(tmp_file);
         if (ivm.size() != size) {
             std::cerr << "ERROR: ivm.size()="<< ivm.size() << " != " << size << std::endl;
             return 1;
@@ -56,29 +56,60 @@ int main(int argc, char* argv[])
             }
         }
 
-        if(ivm != stdv) {
-        	std::cerr << "ERROR: std::vector CMP failed.";
+        if (ivm != stdv) {
+            std::cerr << "ERROR: std::vector CMP failed.";
         }
-        if(ivm != iv) {
-        	std::cerr << "ERROR: iv CMP failed.";
+        if (ivm != iv) {
+            std::cerr << "ERROR: iv CMP failed.";
         }
-        if(ivm != ivf) {
-        	std::cerr << "ERROR: ivf CMP failed.";
+        if (ivm != ivf) {
+            std::cerr << "ERROR: ivf CMP failed.";
         }
     }
 
-    // (3) remove the file as the mapper does not do that 
+    // (2) open read+write! memory map the content of tmp_file
     {
-    	sdsl::remove(tmp_file);
+        int_vector_mapper<0> ivm(tmp_file);
+        if (ivm.size() != size) {
+            std::cerr << "ERROR: ivm.size()="<< ivm.size() << " != " << size << std::endl;
+            return 1;
+        }
+        if (ivm.width() != width) {
+            std::cerr << "ERROR: ivm.width()="<< ivm.width() << " != " << width << std::endl;
+            return 1;
+        }
+        rng.seed(13); // To get the same values than before use the same seed
+        for (uint64_t i=0; i<ivm.size(); ++i) {
+            uint64_t expected_value = rng();
+            if (ivm[i] != expected_value) {
+                std::cerr << "ERROR: ivm["<< i << "]=" << ivm[i] << " != " << expected_value << "= expected_value" << std::endl;
+                return 1;
+            }
+        }
+
+        if (ivm != stdv) {
+            std::cerr << "ERROR: std::vector CMP failed.";
+        }
+        if (ivm != iv) {
+            std::cerr << "ERROR: iv CMP failed.";
+        }
+        if (ivm != ivf) {
+            std::cerr << "ERROR: ivf CMP failed.";
+        }
+    }
+
+    // (3) remove the file as the mapper does not do that if we don't specify it
+    {
+        sdsl::remove(tmp_file);
     }
 
     {
-    	auto tmp_buf = temp_file_buffer<64>::create();
-    	for(const auto& val : stdv) {
-    		tmp_buf.push_back(val);
-    	}
-        if(tmp_buf != stdv) {
-        	std::cerr << "ERROR: tmp_buf CMP failed." << std::endl;
+        auto tmp_buf = temp_file_buffer<64>::create();
+        for (const auto& val : stdv) {
+            tmp_buf.push_back(val);
+        }
+        if (tmp_buf != stdv) {
+            std::cerr << "ERROR: tmp_buf CMP failed." << std::endl;
         }
 
         // tmp buf file is deleted automatically

--- a/include/sdsl/int_vector.hpp
+++ b/include/sdsl/int_vector.hpp
@@ -48,7 +48,7 @@
 #include <initializer_list>
 #include <type_traits>
 #include <vector>
-
+#include <ios>
 
 //! Namespace for the succinct data structure library.
 namespace sdsl
@@ -86,7 +86,7 @@ class int_vector_iterator;
 template<class t_int_vector>
 class int_vector_const_iterator;
 
-template<uint8_t t_width>
+template<uint8_t t_width,std::ios_base::openmode t_mode>
 class int_vector_mapper;
 
 template<uint8_t b, uint8_t t_patter_len>  // forward declaration
@@ -273,11 +273,11 @@ class int_vector
         friend class  int_vector_iterator_base<int_vector>;
         friend class  int_vector_iterator<int_vector>;
         friend class  int_vector_const_iterator<int_vector>;
-        friend class  int_vector_mapper<t_width>;
+        template<uint8_t,std::ios_base::openmode> friend class int_vector_mapper;
         friend class  coder::elias_delta;
         friend class  coder::elias_gamma;
         friend class  coder::fibonacci;
-	template<uint8_t> friend class coder::comma;
+        template<uint8_t> friend class coder::comma;
         friend class  memory_manager;
 
         enum { fixed_int_width = t_width }; // make template parameter accessible
@@ -304,7 +304,7 @@ class int_vector
         int_vector(std::initializer_list<t_T> il) : int_vector() {
             resize(il.size());
             size_type idx = 0;
-for (auto x : il) {
+            for (auto x : il) {
                 (*this)[idx++] = x;
             }
         }
@@ -1113,7 +1113,7 @@ template<class t_bv>
 inline typename std::enable_if<std::is_same<typename t_bv::index_category ,bv_tag>::value, std::ostream&>::type
 operator<<(std::ostream& os, const t_bv& bv)
 {
-for (auto b : bv) {
+    for (auto b : bv) {
         os << b;
     }
     return os;
@@ -1206,14 +1206,14 @@ template<uint8_t t_width>
 auto int_vector<t_width>::get_int(size_type idx, const uint8_t len)const -> value_type
 {
 #ifdef SDSL_DEBUG
-if (idx+len > m_size) {
-throw std::out_of_range("OUT_OF_RANGE_ERROR: int_vector::get_int(size_type, uint8_t); idx+len > size()!");
-}
-if (len > 64) {
-throw std::out_of_range("OUT_OF_RANGE_ERROR: int_vector::get_int(size_type, uint8_t); len>64!");
-}
+    if (idx+len > m_size) {
+        throw std::out_of_range("OUT_OF_RANGE_ERROR: int_vector::get_int(size_type, uint8_t); idx+len > size()!");
+    }
+    if (len > 64) {
+        throw std::out_of_range("OUT_OF_RANGE_ERROR: int_vector::get_int(size_type, uint8_t); len>64!");
+    }
 #endif
-return bits::read_int(m_data+(idx>>6), idx&0x3F, len);
+    return bits::read_int(m_data+(idx>>6), idx&0x3F, len);
 }
 
 template<uint8_t t_width>

--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -5,284 +5,344 @@
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <cstdio>
+#include <ios>
 
-namespace sdsl {
+namespace sdsl
+{
 
-template <uint8_t t_width = 0>
-class int_vector_mapper {
-    static_assert(t_width <= 64,
-                  "int_vector_mapper: width must be at most 64 bits.");
-public:
-    typedef typename int_vector<t_width>::difference_type difference_type;
-    typedef typename int_vector<t_width>::value_type value_type;
-    typedef typename int_vector<t_width>::size_type size_type;
-    typedef typename int_vector<t_width>::int_width_type width_type;
-public:
-    const size_type append_block_size = 1000000;
-private:
-    uint8_t* m_mapped_data = nullptr;
-    uint64_t m_file_size_bytes = 0;
-    off_t m_data_offset = 0;
-    int m_fd = -1;
-    int_vector<t_width> m_wrapper;
-    std::string m_file_name;
-    bool m_delete_on_close;
-public:
-    int_vector_mapper() = delete;
-    int_vector_mapper(const int_vector_mapper&) = delete;
-    int_vector_mapper& operator=(const int_vector_mapper&) = delete;
-public:
-    ~int_vector_mapper() {
-        if (m_mapped_data) {
-            if (m_data_offset) {
-                // update size in the on disk representation and
-                // truncate if necessary
-                uint64_t* size_in_file = (uint64_t*)m_mapped_data;
-                if (*size_in_file != m_wrapper.m_size) {
-                    *size_in_file = m_wrapper.m_size;
+template <uint8_t t_width = 0,std::ios_base::openmode t_mode = std::ios_base::out|std::ios_base::in>
+class int_vector_mapper
+{
+        static_assert(t_width <= 64,
+                      "int_vector_mapper: width must be at most 64 bits.");
+    public:
+        typedef typename int_vector<t_width>::difference_type difference_type;
+        typedef typename int_vector<t_width>::value_type value_type;
+        typedef typename int_vector<t_width>::size_type size_type;
+        typedef typename int_vector<t_width>::int_width_type width_type;
+    public:
+        const size_type append_block_size = 1000000;
+    private:
+        uint8_t* m_mapped_data = nullptr;
+        uint64_t m_file_size_bytes = 0;
+        off_t m_data_offset = 0;
+        int m_fd = -1;
+        int_vector<t_width> m_wrapper;
+        std::string m_file_name;
+        bool m_delete_on_close;
+    private:
+        void mmap_file() {
+            if (!(t_mode&std::ios_base::out)) {  // read only
+                m_mapped_data = (uint8_t*)mmap(NULL,
+                                               m_file_size_bytes,
+                                               PROT_READ,
+                                               MAP_SHARED,
+                                               m_fd, 0);
+            } else {
+                m_mapped_data = (uint8_t*)mmap(NULL,
+                                               m_file_size_bytes,
+                                               PROT_READ|PROT_WRITE,
+                                               MAP_SHARED,
+                                               m_fd, 0);
+            }
+            if (m_mapped_data == MAP_FAILED) {
+                std::string mmap_error
+                    = std::string("int_vector_mapper: mmap error. ")
+                      + std::string(strerror(errno));
+                throw std::runtime_error(mmap_error);
+            }
+            auto ret = madvise(m_mapped_data, m_file_size_bytes, MADV_SEQUENTIAL);
+            if (ret == -1) {
+                perror("Error trying to hint sequential access");
+            }
+        }
+    public:
+        int_vector_mapper() = delete;
+        int_vector_mapper(const int_vector_mapper&) = delete;
+        int_vector_mapper& operator=(const int_vector_mapper&) = delete;
+    public:
+        ~int_vector_mapper() {
+            if (m_mapped_data) {
+                if (t_mode&std::ios_base::out) { // write was possible
+                    if (m_data_offset) {
+                        // update size in the on disk representation and
+                        // truncate if necessary
+                        uint64_t* size_in_file = (uint64_t*)m_mapped_data;
+                        if (*size_in_file != m_wrapper.m_size) {
+                            *size_in_file = m_wrapper.m_size;
+                        }
+                        if (t_width==0) {
+                            // if size is variable and we map a sdsl vector
+                            // we might have to update the stored width
+                            uint8_t stored_width = m_mapped_data[8];
+                            if (stored_width != m_wrapper.m_width) {
+                                m_mapped_data[8] = m_wrapper.m_width;
+                            }
+                        }
+                    }
                 }
-                if(t_width==0) {
-                    // if size is variable and we map a sdsl vector
-                    // we might have to update the stored width
-                    uint8_t stored_width = m_mapped_data[8];
-                    if (stored_width != m_wrapper.m_width) {
-                        m_mapped_data[8] = m_wrapper.m_width;
+
+                munmap(m_mapped_data, m_file_size_bytes);
+
+                if (t_mode&std::ios_base::out) {
+                    // do we have to truncate?
+                    size_type current_bit_size = m_wrapper.m_size;
+                    size_type data_size_in_bytes = ((current_bit_size + 63) >> 6) << 3;
+                    if (m_file_size_bytes != data_size_in_bytes + m_data_offset) {
+                        int tret = ftruncate(m_fd, data_size_in_bytes + m_data_offset);
+                        if (tret == -1) {
+                            std::string truncate_error
+                                = std::string("int_vector_mapper: truncate error. ")
+                                  + std::string(strerror(errno));
+                            throw std::runtime_error(truncate_error);
+                        }
                     }
                 }
             }
-            // do we have to truncate?
-            size_type current_bit_size = m_wrapper.m_size;
-            size_type data_size_in_bytes = ((current_bit_size + 63) >> 6) << 3;
-            munmap(m_mapped_data, m_file_size_bytes);
-            if (m_file_size_bytes != data_size_in_bytes + m_data_offset) {
-                int tret = ftruncate(m_fd, data_size_in_bytes + m_data_offset);
+            if (m_fd != -1) {
+                close(m_fd);
+                if (m_delete_on_close) {
+                    int ret_code = sdsl::remove(m_file_name);
+                    if (ret_code != 0) {
+                        std::cerr << "int_vector_mapper: error deleting file '"
+                                  << m_file_name << "': " << ret_code << std::endl;
+                    }
+                }
+            }
+            m_wrapper.m_data = nullptr;
+            m_wrapper.m_size = 0;
+        }
+        int_vector_mapper(int_vector_mapper&& ivm) {
+            m_wrapper.m_data = ivm.m_wrapper.m_data;
+            m_wrapper.m_size = ivm.m_wrapper.m_size;
+            m_wrapper.width(ivm.m_wrapper.width());
+            m_file_name = ivm.m_file_name;
+            m_delete_on_close = ivm.m_delete_on_close;
+            ivm.m_wrapper.m_data = nullptr;
+            ivm.m_wrapper.m_size = 0;
+            ivm.m_mapped_data = nullptr;
+            ivm.m_fd = -1;
+        }
+        int_vector_mapper& operator=(int_vector_mapper&& ivm) {
+            m_wrapper.m_data = ivm.m_wrapper.m_data;
+            m_wrapper.m_size = ivm.m_wrapper.m_size;
+            m_wrapper.width(ivm.m_wrapper.width());
+            m_file_name = ivm.m_file_name;
+            m_delete_on_close = ivm.m_delete_on_close;
+            ivm.m_wrapper.m_data = nullptr;
+            ivm.m_wrapper.m_size = 0;
+            ivm.m_mapped_data = nullptr;
+            ivm.m_fd = -1;
+            return (*this);
+        }
+        int_vector_mapper(const std::string& key,const cache_config& config)
+            : int_vector_mapper(cache_file_name(key, config)) {}
+        int_vector_mapper(const std::string filename,
+                          bool is_plain = false,
+                          bool delete_on_close = false) :
+            m_file_name(filename), m_delete_on_close(delete_on_close) {
+            size_type size_in_bits = 0;
+            uint8_t int_width = t_width;
+            {
+                std::ifstream f(filename);
+                if (!f.is_open()) {
+                    throw std::runtime_error(
+                        "int_vector_mapper: file does not exist.");
+                }
+                if (!is_plain) {
+                    int_vector<t_width>::read_header(size_in_bits, int_width, f);
+                }
+            }
+            m_file_size_bytes = util::file_size(filename);
+
+            if (!is_plain) {
+                m_data_offset = t_width ? 8 : 9;
+            } else {
+                if (8 != t_width and 16 != t_width and 32 != t_width and 64
+                    != t_width) {
+                    throw std::runtime_error("int_vector_mapper: plain vector can "
+                                             "only be of width 8, 16, 32, 64.");
+                }
+                size_in_bits = m_file_size_bytes * 8;
+            }
+
+            // open backend file depending on mode
+            if (!(t_mode&std::ios_base::out))
+                m_fd = open(filename.c_str(), O_RDONLY);
+            else
+                m_fd = open(filename.c_str(), O_RDWR);
+
+            if (m_fd == -1) {
+                std::string open_error
+                    = std::string("int_vector_mapper: open file error.")
+                      + std::string(strerror(errno));
+                throw std::runtime_error(open_error);
+            }
+
+            // prepare for mmap
+            size_type new_size_in_bytes = ((size_in_bits + 63) >> 6) << 3;
+            m_file_size_bytes = new_size_in_bytes + m_data_offset;
+            m_wrapper.width(int_width);
+            mmap_file();
+            m_wrapper.m_size = size_in_bits;
+            m_wrapper.m_data = (uint64_t*)(m_mapped_data + m_data_offset);
+        }
+        std::string file_name() const { return m_file_name; }
+        width_type width() const { return m_wrapper.width(); }
+        void width(const uint8_t new_int_width) {
+            static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'width'");
+            m_wrapper.width(new_int_width);
+        }
+        size_type size() const {
+            return m_wrapper.size();
+        }
+        void bit_resize(const size_type bit_size) {
+            static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'bit_resize'");
+            size_type new_size_in_bytes = ((bit_size + 63) >> 6) << 3;
+            if (m_file_size_bytes != new_size_in_bytes + m_data_offset) {
+                if (m_mapped_data) munmap(m_mapped_data, m_file_size_bytes);
+                int tret = ftruncate(m_fd, new_size_in_bytes + m_data_offset);
                 if (tret == -1) {
                     std::string truncate_error
                         = std::string("int_vector_mapper: truncate error. ")
                           + std::string(strerror(errno));
                     throw std::runtime_error(truncate_error);
                 }
+                m_file_size_bytes = new_size_in_bytes + m_data_offset;
             }
-        }
-        if (m_fd != -1) {
-            close(m_fd);
-            if(m_delete_on_close) {
-                sdsl::remove(m_file_name);
-            }
-        }
-        m_wrapper.m_data = nullptr;
-        m_wrapper.m_size = 0;
-    }
-    int_vector_mapper(int_vector_mapper&& ivm) {
-        m_wrapper.m_data = ivm.m_wrapper.m_data;
-        m_wrapper.m_size = ivm.m_wrapper.m_size;
-        m_wrapper.width(ivm.m_wrapper.width());
-        m_file_name = ivm.m_file_name;
-        m_delete_on_close = ivm.m_delete_on_close;
-        ivm.m_wrapper.m_data = nullptr;
-        ivm.m_wrapper.m_size = 0;
-        ivm.m_mapped_data = nullptr;
-        ivm.m_fd = -1;
-    }
-    int_vector_mapper& operator=(int_vector_mapper&& ivm) {
-        m_wrapper.m_data = ivm.m_wrapper.m_data;
-        m_wrapper.m_size = ivm.m_wrapper.m_size;
-        m_wrapper.width(ivm.m_wrapper.width());
-        m_file_name = ivm.m_file_name;
-        m_delete_on_close = ivm.m_delete_on_close;
-        ivm.m_wrapper.m_data = nullptr;
-        ivm.m_wrapper.m_size = 0;
-        ivm.m_mapped_data = nullptr;
-        ivm.m_fd = -1;
-        return (*this);
-    }
-    int_vector_mapper(const std::string& key,const cache_config& config)
-        : int_vector_mapper(cache_file_name(key, config)) {}
-    int_vector_mapper(const std::string filename, 
-                      bool is_plain = false, 
-                      bool delete_on_close = false) :
-        m_file_name(filename), m_delete_on_close(delete_on_close)
-    {
-        size_type size_in_bits = 0;
-        uint8_t int_width = t_width;
-        {
-            std::ifstream f(filename);
-            if (!f.is_open()) {
-                throw std::runtime_error(
-                    "int_vector_mapper: file does not exist.");
-            }
-            if (!is_plain) {
-                int_vector<t_width>::read_header(size_in_bits, int_width, f);
-            }
-        }
-        m_file_size_bytes = util::file_size(filename);
 
-        if (!is_plain) {
-            m_data_offset = t_width ? 8 : 9;
-        } else {
-            if (8 != t_width and 16 != t_width and 32 != t_width and 64
-                != t_width) {
-                throw std::runtime_error("int_vector_mapper: plain vector can "
-                                         "only be of width 8, 16, 32, 64.");
-            }
-            size_in_bits = m_file_size_bytes * 8;
+            // perform the actual mapping
+            mmap_file();
+
+            // update wrapper
+            m_wrapper.m_data = (uint64_t*)(m_mapped_data + m_data_offset);
+            m_wrapper.m_size = bit_size;
         }
 
-        // open backend file
-        m_fd = open(filename.c_str(), O_RDWR);
-        if (m_fd == -1) {
-            std::string open_error
-                = std::string("int_vector_mapper: open file error. ")
-                  + std::string(strerror(errno));
-            throw std::runtime_error(open_error);
-        }
 
-        // prepare wrapper and mmap
-        width(int_width);
-        bit_resize(size_in_bits);
-    }
-    std::string file_name() const { return m_file_name; }
-    width_type width() const { return m_wrapper.width(); }
-    void width(const uint8_t new_int_width) {
-        m_wrapper.width(new_int_width);
-    }
-    size_type size() const { return m_wrapper.size(); }
-    void bit_resize(const size_type bit_size) {
-        size_type new_size_in_bytes = ((bit_size + 63) >> 6) << 3;
-        if (m_file_size_bytes != new_size_in_bytes + m_data_offset) {
-            if (m_mapped_data) munmap(m_mapped_data, m_file_size_bytes);
-            int tret = ftruncate(m_fd, new_size_in_bytes + m_data_offset);
-            if (tret == -1) {
-                std::string truncate_error
-                    = std::string("int_vector_mapper: truncate error. ")
-                      + std::string(strerror(errno));
-                throw std::runtime_error(truncate_error);
-            }
-            m_file_size_bytes = new_size_in_bytes + m_data_offset;
-        }
-        m_mapped_data
-            = (uint8_t*)mmap(NULL, m_file_size_bytes, PROT_READ | PROT_WRITE,
-                             MAP_SHARED, m_fd, 0);
-        if (m_mapped_data == MAP_FAILED) {
-            std::string mmap_error
-                = std::string("int_vector_mapper: mmap error. ")
-                  + std::string(strerror(errno));
-            throw std::runtime_error(mmap_error);
-        }
-        auto ret = madvise(m_mapped_data, m_file_size_bytes, MADV_SEQUENTIAL);
-        if (ret == -1) {
-            perror("Error trying to hint sequential access");
-        }
-        // update wrapper
-        m_wrapper.m_data = (uint64_t*)(m_mapped_data + m_data_offset);
-        m_wrapper.m_size = bit_size;
-    }
-    void resize(const size_type size) {
-        size_type size_in_bits = size * width();
-        bit_resize(size_in_bits);
-    }
-    auto begin() -> typename int_vector<t_width>::iterator {
-        return m_wrapper.begin();
-    }
-    auto end() -> typename int_vector<t_width>::iterator {
-        return m_wrapper.end();
-    }
-    auto begin() const -> typename int_vector<t_width>::const_iterator {
-        return m_wrapper.begin();
-    }
-    auto end() const -> typename int_vector<t_width>::const_iterator {
-        return m_wrapper.end();
-    }
-    auto operator[](const size_type& idx) const
-        -> typename int_vector<t_width>::const_reference
-    {
-        return m_wrapper[idx];
-    }
-    auto operator[](const size_type& idx)
-        -> typename int_vector<t_width>::reference
-    {
-        return m_wrapper[idx];
-    }
-    const uint64_t* data() const { return m_wrapper.data(); }
-    uint64_t* data() { return m_wrapper.data(); }
-    value_type get_int(size_type idx, const uint8_t len = 64) const {
-        return m_wrapper.get_int(idx, len);
-    }
-    void set_int(size_type idx, value_type x, const uint8_t len = 64) {
-        m_wrapper.set_int(idx, x, len);
-    }
-    void push_back(value_type x) {
-        if (capacity() < size() + 1) {
-            size_type old_size = m_wrapper.m_size;
-            size_type size_in_bits = (size() + append_block_size) * width();
+        void resize(const size_type size) {
+            static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'resize'");
+            size_type size_in_bits = size * width();
             bit_resize(size_in_bits);
-            m_wrapper.m_size = old_size;
         }
-        m_wrapper[size()] = x;
-        // update size in wrapper only
-        m_wrapper.m_size += width();
-    }
-    size_type capacity() const {
-        size_t data_size_in_bits = 8 * (m_file_size_bytes - m_data_offset);
-        return data_size_in_bits / width();
-    }
-    size_type bit_size() const {
-        return m_wrapper.bit_size();
-    }
-    template<class container>
-    bool operator==(const container& v) const {
-        return std::equal( begin(), end(), v.begin());
-    }
-    bool operator==(const int_vector<t_width>& v) const {
-        return m_wrapper == v;
-    }
-    bool operator==(const int_vector_mapper& v) const {
-        return m_wrapper == v.m_wrapper;
-    }
-    template<class container>
-    bool operator!=(const container& v) const {
-        return !(*this==v);
-    }
-    void flip() {
-        m_wrapper.flip();
-    }
-    bool empty() const {
-        return m_wrapper.empty();
-    }
+
+        auto begin() -> typename int_vector<t_width>::iterator {
+            static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'begin'");
+            return m_wrapper.begin();
+        }
+        auto end() -> typename int_vector<t_width>::iterator {
+            static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'end'");
+            return m_wrapper.end();
+        }
+        auto begin() const -> typename int_vector<t_width>::const_iterator {
+            return m_wrapper.begin();
+        }
+        auto end() const -> typename int_vector<t_width>::const_iterator {
+            return m_wrapper.end();
+        }
+        auto cbegin() const -> typename int_vector<t_width>::const_iterator {
+            return m_wrapper.begin();
+        }
+        auto cend() const -> typename int_vector<t_width>::const_iterator {
+            return m_wrapper.end();
+        }
+        auto operator[](const size_type& idx) const
+        -> typename int_vector<t_width>::const_reference {
+            return m_wrapper[idx];
+        }
+        auto operator[](const size_type& idx)
+        -> typename int_vector<t_width>::reference {
+            static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'operator[]'");
+            return m_wrapper[idx];
+        }
+        const uint64_t* data() const { return m_wrapper.data(); }
+        uint64_t* data() {
+            static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'data'");
+            return m_wrapper.data();
+        }
+        value_type get_int(size_type idx, const uint8_t len = 64) const {
+            return m_wrapper.get_int(idx, len);
+        }
+        void set_int(size_type idx, value_type x, const uint8_t len = 64) {
+            static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'set_int'");
+            m_wrapper.set_int(idx, x, len);
+        }
+        void push_back(value_type x) {
+            static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'push_back'");
+            if (capacity() < size() + 1) {
+                size_type old_size = m_wrapper.m_size;
+                size_type size_in_bits = (size() + append_block_size) * width();
+                bit_resize(size_in_bits);
+                m_wrapper.m_size = old_size;
+            }
+            // update size in wrapper only
+            m_wrapper.m_size += width();
+            m_wrapper[size()-1] = x;
+        }
+        size_type capacity() const {
+            size_t data_size_in_bits = 8 * (m_file_size_bytes - m_data_offset);
+            return data_size_in_bits / width();
+        }
+        size_type bit_size() const {
+            return m_wrapper.bit_size();
+        }
+        template<class container>
+        bool operator==(const container& v) const {
+            return std::equal(begin(), end(), v.begin());
+        }
+        bool operator==(const int_vector<t_width>& v) const {
+            return m_wrapper == v;
+        }
+        bool operator==(const int_vector_mapper& v) const {
+            return m_wrapper == v.m_wrapper;
+        }
+        template<class container>
+        bool operator!=(const container& v) const {
+            return !(*this==v);
+        }
+        void flip() {
+            static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'flip'");
+            m_wrapper.flip();
+        }
+        bool empty() const {
+            return m_wrapper.empty();
+        }
 };
 
 template <uint8_t t_width = 0>
-class temp_file_buffer {
-private:
-    static std::string tmp_file(const std::string& dir) {
-        char tmp_file_name[1024] = {0};
-        sprintf (tmp_file_name, "%s/tmp_mapper_file_XXXXXX.sdsl",dir.c_str());
-        int fd = mkstemps(tmp_file_name,5);
-        if(fd == -1) {
-            throw std::runtime_error("could not create temporary file.");
+class temp_file_buffer
+{
+    private:
+        static std::string tmp_file(const std::string& dir) {
+            char tmp_file_name[1024] = {0};
+            sprintf(tmp_file_name, "%s/tmp_mapper_file_XXXXXX.sdsl",dir.c_str());
+            int fd = mkstemps(tmp_file_name,5);
+            if (fd == -1) {
+                throw std::runtime_error("could not create temporary file.");
+            }
+            close(fd);
+            return std::string(tmp_file_name,strlen(tmp_file_name));
         }
-        close(fd);
-        return std::string(tmp_file_name,strlen(tmp_file_name));
-    }
-public:
-    static int_vector_mapper<t_width> create() {
-        auto file_name = tmp_file("/tmp");
-        return create(file_name);
-    }
-    static int_vector_mapper<t_width> create(const cache_config& config) {
-        auto file_name = tmp_file(config.dir);
-        return create(file_name);
-    }
-    static int_vector_mapper<t_width> create(const std::string& file_name) {
-        //write empty int_vector to init the file
-        int_vector<t_width> tmp_vector;
-        store_to_file(tmp_vector,file_name);
-        return int_vector_mapper<t_width>(file_name,false,true);
-    }
+    public:
+        static int_vector_mapper<t_width> create() {
+            auto file_name = tmp_file("/tmp");
+            return create(file_name);
+        }
+        static int_vector_mapper<t_width> create(const cache_config& config) {
+            auto file_name = tmp_file(config.dir);
+            return create(file_name);
+        }
+        static int_vector_mapper<t_width> create(const std::string& file_name) {
+            //write empty int_vector to init the file
+            int_vector<t_width> tmp_vector;
+            store_to_file(tmp_vector,file_name);
+            return int_vector_mapper<t_width,std::ios_base::out|std::ios_base::in>(file_name,false,true);
+        }
 };
 
-typedef int_vector_mapper<1> bit_vector_mapper;
+template<std::ios_base::openmode t_mode = std::ios_base::out|std::ios_base::in>
+using bit_vector_mapper = int_vector_mapper<1,t_mode>;
 
 } // end of namespace
 
-#endif 
+#endif

--- a/test/IntVectorMapperTest.cpp
+++ b/test/IntVectorMapperTest.cpp
@@ -51,13 +51,13 @@ TEST_F(IntVectorMapperTest, iterator)
             sdsl::serialize_vector(vec,ofs);
         }
         {
-            sdsl::int_vector_mapper<64> ivm("tmp/int_vector_mapper_itrtest",true);
+            const sdsl::int_vector_mapper<64,std::ios_base::in> ivm("tmp/int_vector_mapper_itrtest",true);
             ASSERT_EQ(size,ivm.size());
             ASSERT_TRUE(std::equal(ivm.begin(),ivm.end(),vec.begin()));
             ASSERT_EQ(size,(size_t)std::distance(ivm.begin(),ivm.end()));
         }
         {
-            sdsl::int_vector_mapper<64> ivm("tmp/int_vector_mapper_itrtest",true);
+            const sdsl::int_vector_mapper<64,std::ios_base::in> ivm("tmp/int_vector_mapper_itrtest",true);
             auto itr = ivm.end()-1;
             for (size_t i=0; i<size; i++) {
                 ASSERT_EQ(*itr,vec[size-i-1]);
@@ -73,13 +73,13 @@ TEST_F(IntVectorMapperTest, iterator)
         sdsl::util::set_to_id(vec);
         store_to_file(vec,"tmp/int_vector_mapper_itrtest");
         {
-            sdsl::int_vector_mapper<25> ivm("tmp/int_vector_mapper_itrtest");
+            const sdsl::int_vector_mapper<25,std::ios_base::in> ivm("tmp/int_vector_mapper_itrtest");
             ASSERT_EQ(size,ivm.size());
             ASSERT_TRUE(std::equal(ivm.begin(),ivm.end(),vec.begin()));
             ASSERT_EQ(size,(size_t)std::distance(ivm.begin(),ivm.end()));
         }
         {
-            sdsl::int_vector_mapper<25> ivm("tmp/int_vector_mapper_itrtest");
+            const sdsl::int_vector_mapper<25,std::ios_base::in> ivm("tmp/int_vector_mapper_itrtest");
             auto itr = ivm.end()-1;
             for (size_t i=0; i<size; i++) {
                 ASSERT_EQ(*itr,vec[size-i-1]);
@@ -96,7 +96,7 @@ TEST_F(IntVectorMapperTest, iterator)
         sdsl::util::bit_compress(vec);
         store_to_file(vec,"tmp/int_vector_mapper_itrtest");
         {
-            sdsl::int_vector_mapper<> ivm("tmp/int_vector_mapper_itrtest");
+            const sdsl::int_vector_mapper<0,std::ios_base::in> ivm("tmp/int_vector_mapper_itrtest");
             ASSERT_EQ(size,ivm.size());
             ASSERT_EQ(vec.width(),ivm.width());
             ASSERT_TRUE(std::equal(ivm.begin(),ivm.end(),vec.begin()));
@@ -231,7 +231,7 @@ TEST_F(IntVectorMapperTest, bitvector_mapping)
         store_to_file(bv,"tmp/bit_vector_mapper_test");
         {
             // load/store test
-            sdsl::bit_vector_mapper bvm("tmp/bit_vector_mapper_test");
+            const sdsl::bit_vector_mapper<std::ios_base::in> bvm("tmp/bit_vector_mapper_test");
             ASSERT_EQ(bvm.size(),bv.size());
             ASSERT_EQ(bvm.width(),bv.width());
             ASSERT_TRUE(std::equal(bvm.begin(),bvm.end(),bv.begin()));
@@ -239,7 +239,7 @@ TEST_F(IntVectorMapperTest, bitvector_mapping)
         }
         {
             // flip test
-            sdsl::bit_vector_mapper bvm("tmp/bit_vector_mapper_test");
+            sdsl::bit_vector_mapper<> bvm("tmp/bit_vector_mapper_test");
             bvm.flip();
             bv.flip();
             ASSERT_TRUE(std::equal(bvm.begin(),bvm.end(),bv.begin()));
@@ -247,7 +247,7 @@ TEST_F(IntVectorMapperTest, bitvector_mapping)
         }
         {
             // load/store after flip
-            sdsl::bit_vector_mapper bvm("tmp/bit_vector_mapper_test");
+            const sdsl::bit_vector_mapper<std::ios_base::in> bvm("tmp/bit_vector_mapper_test");
             ASSERT_TRUE(std::equal(bvm.begin(),bvm.end(),bv.begin()));
             ASSERT_EQ(sdsl::util::cnt_one_bits(bv),sdsl::util::cnt_one_bits(bvm));
         }


### PR DESCRIPTION
This fixes issue #202 where I added stuff to the invector before
updating the size.

Additionally, this commit also adds additional type safety features to
the int-vector-mapper. The mapper now has an additional template
parameter:

`
template <t_width,t_mode> class int_vector_mapper
`

where the ``open mode'' can be specified. For example,

`
const int_vector_mapper<0,std::ios_base::in> ivm(tmp_file);
`

maps a file in read only mode. thus, only operations which do not modify
the underlying file are permitted. Using other operations causes a
compilation error.

The default mode remains read+write so existing code is not affected:

`
int_vector_mapper<0,std::ios_base::out|std::ios_base::in> ivm(tmp_file);
`

is equal to

`
int_vector_mapper<> ivm(tmp_file);
`

the examples and tests are adjusted accordingly.
