### PR TITLE
Reference-Return at post-increment

### DIFF
--- a/include/sdsl/cst_sct3.hpp
+++ b/include/sdsl/cst_sct3.hpp
@@ -621,7 +621,7 @@ class cst_sct3
          *  \par Time complexity
          *     \f$ \Order{1}\f$
          */
-        cst_node_child_proxy<cst_sct3> children(const node_type v) const
+        cst_node_child_proxy<cst_sct3> children(const node_type& v) const
         {
             return cst_node_child_proxy<cst_sct3>(this,v);
         }

--- a/include/sdsl/suffix_tree_helper.hpp
+++ b/include/sdsl/suffix_tree_helper.hpp
@@ -36,7 +36,7 @@ class cst_node_child_proxy_iterator : public std::iterator<std::forward_iterator
             m_cur_node = m_cst->sibling(m_cur_node);
             return *this;
         }
-        iterator_type& operator++(int) {
+        iterator_type operator++(int) {
             iterator_type it = *this;
             ++(*this);
             return it;


### PR DESCRIPTION
One of my students has found a bug that caused runtime failure for gcc 4.9 and clang 3.5.0 when using the `-O0` debug optimization.
Here is a patch that also changes `children` to a call-by-reference (possible speed-up).
