### PR TITLE
Adding target_include_directories directive to auto include headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.11)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 include(AppendCompilerFlags)
 


### PR DESCRIPTION
This is useful when an external project uses sdsl-lite as a component via add_subdirectory(...) command. Extracted from http://stackoverflow.com/a/18697099 .
