### PR TITLE
Fix for issue #210

### DIFF
--- a/include/sdsl/csa_alphabet_strategy.hpp
+++ b/include/sdsl/csa_alphabet_strategy.hpp
@@ -220,6 +220,8 @@ class succinct_byte_alphabet
                 char2comp_wrapper(const succinct_byte_alphabet* strat) : m_strat(strat) {}
                 comp_char_type operator[](char_type c) const
                 {
+                   if ( c >= m_strat->m_char.size() or !m_strat->m_char[c] )
+                        return (comp_char_type)0;
                     return (comp_char_type) m_strat->m_char_rank((size_type)c);
                 }
         };
@@ -418,10 +420,15 @@ class int_alphabet
                 comp_char_type operator[](char_type c) const
                 {
                     if (m_strat->m_char.size() > 0) {  // if alphabet is not continuous
+                        if ( c >= m_strat->m_char.size() or !m_strat->m_char[c] )
+                            return (comp_char_type)0;
                         return (comp_char_type) m_strat->m_char_rank((size_type)c);
                     } else { // direct map if it is continuous
+                        if ( c >= m_strat->m_sigma )
+                            return 0;
                         return (comp_char_type) c;
                     }
+                    return 0;
                 }
         };
 

--- a/include/sdsl/io.hpp
+++ b/include/sdsl/io.hpp
@@ -794,6 +794,17 @@ operator<<(std::ostream& os, const std::vector<t_int>& v)
     return os;
 }
 
+template<class t_iv>
+inline typename std::enable_if<std::is_same<typename t_iv::category ,csa_member_tag>::value, std::ostream&>::type
+operator<<(std::ostream& os, const t_iv& v)
+{
+    for (auto it=v.begin(), end = v.end(); it != end; ++it) {
+        os << *it;
+        if (it+1 != end and std::is_same<typename t_iv::alphabet_category,int_alphabet_tag>::value) os << " ";
+    }
+    return os;
+}
+
 
 
 

--- a/include/sdsl/sdsl_concepts.hpp
+++ b/include/sdsl/sdsl_concepts.hpp
@@ -36,6 +36,8 @@ struct wt_tag {};  // wavelet tree tag
 struct psi_tag {}; // tag for CSAs based on the psi function
 struct lf_tag {}; // tag for CSAs based on the LF function
 
+struct csa_member_tag {}; // tag for text, bwt, LF, \Psi members of CSA 
+
 struct lcp_plain_tag {};
 struct lcp_permuted_tag {};
 struct lcp_tree_compressed_tag {};

--- a/include/sdsl/suffix_array_helper.hpp
+++ b/include/sdsl/suffix_array_helper.hpp
@@ -37,7 +37,7 @@ namespace sdsl
  *    \f$ \Order{\log \sigma} \f$
  *  TODO: add hinted binary search? Two way binary search?
 */
-template <class t_csa>
+template <typename t_csa>
 typename t_csa::char_type first_row_symbol(const typename t_csa::size_type i, const t_csa& csa)
 {
     assert(i < csa.size());
@@ -64,7 +64,7 @@ typename t_csa::char_type first_row_symbol(const typename t_csa::size_type i, co
 }
 
 // psi[] trait
-template<class t_csa, bool t_direction>
+template<typename t_csa, bool t_direction>
 struct traverse_csa_psi_trait {
     typedef typename t_csa::value_type value_type;
     typedef typename t_csa::size_type size_type;
@@ -75,7 +75,7 @@ struct traverse_csa_psi_trait {
 };
 
 // lf[] trait
-template<class t_csa>
+template<typename t_csa>
 struct traverse_csa_psi_trait<t_csa,false> {
     typedef typename t_csa::value_type value_type;
     typedef typename t_csa::size_type size_type;
@@ -88,7 +88,7 @@ struct traverse_csa_psi_trait<t_csa,false> {
     }
 };
 
-template<class t_csa,bool t_direction>
+template<typename t_csa,bool t_direction>
 class traverse_csa_psi
 {
     public:
@@ -96,6 +96,8 @@ class traverse_csa_psi
         typedef typename t_csa::size_type                             size_type;
         typedef typename t_csa::difference_type                 difference_type;
         typedef random_access_const_iterator<traverse_csa_psi>   const_iterator;
+        typedef csa_member_tag                                         category;
+        typedef int_alphabet_tag                              alphabet_category;                    
 
     private:
         const t_csa& m_csa;
@@ -142,7 +144,7 @@ class traverse_csa_psi
 };
 
 // psi[] trait
-template<class t_csa,bool t_direction>
+template<typename t_csa,bool t_direction>
 struct traverse_csa_saisa_trait {
     typedef typename t_csa::value_type value_type;
     typedef typename t_csa::size_type size_type;
@@ -154,7 +156,7 @@ struct traverse_csa_saisa_trait {
 };
 
 // lf[] trait
-template<class t_csa>
+template<typename t_csa>
 struct traverse_csa_saisa_trait<t_csa,false> {
     typedef typename t_csa::value_type value_type;
     typedef typename t_csa::size_type size_type;
@@ -168,7 +170,7 @@ struct traverse_csa_saisa_trait<t_csa,false> {
 };
 
 //! A helper class for the \f$\Psi\f$ function for (compressed) suffix arrays which provide also the inverse suffix array values (like sdsl::csa_bitcompressed).
-template<class t_csa,bool t_direction>
+template<typename t_csa,bool t_direction>
 class traverse_csa_saisa
 {
     public:
@@ -176,6 +178,8 @@ class traverse_csa_saisa
         typedef typename t_csa::size_type size_type;
         typedef typename t_csa::difference_type	difference_type;
         typedef random_access_const_iterator<traverse_csa_saisa> const_iterator;// STL Container requirement
+        typedef csa_member_tag                                         category;
+        typedef int_alphabet_tag                              alphabet_category;
     private:
         const t_csa& m_csa;
     public:
@@ -228,7 +232,7 @@ class traverse_csa_saisa
 };
 
 //! A wrapper for the bwt of a compressed suffix array that is based on the \f$\psi\f$ function.
-template<class t_csa>
+template<typename t_csa>
 class bwt_of_csa_psi
 {
     public:
@@ -237,6 +241,8 @@ class bwt_of_csa_psi
         typedef typename t_csa::char_type char_type;
         typedef typename t_csa::difference_type difference_type;
         typedef random_access_const_iterator<bwt_of_csa_psi> const_iterator;
+        typedef csa_member_tag                               category;
+        typedef typename t_csa::alphabet_category            alphabet_category;
     private:
         const t_csa& m_csa; //<- pointer to the (compressed) suffix array that is based on the \f$\Psi\f$ function.
     public:
@@ -314,7 +320,7 @@ class bwt_of_csa_psi
 };
 
 // psi[] trait
-template<class t_csa,bool t_direction>
+template<typename t_csa,bool t_direction>
 struct traverse_csa_wt_traits {
     typedef typename t_csa::value_type value_type;
     typedef typename t_csa::char_type char_type;
@@ -327,7 +333,7 @@ struct traverse_csa_wt_traits {
 };
 
 // lf[] trait
-template<class t_csa>
+template<typename t_csa>
 struct traverse_csa_wt_traits<t_csa,false> {
     typedef typename t_csa::value_type value_type;
     typedef typename t_csa::char_type char_type;
@@ -344,7 +350,7 @@ struct traverse_csa_wt_traits<t_csa,false> {
 
 
 //! A wrapper class for the \f$\Psi\f$ and LF function for (compressed) suffix arrays that are based on a wavelet tree (like sdsl::csa_wt).
-template<class t_csa,bool t_direction>
+template<typename t_csa,bool t_direction>
 class traverse_csa_wt
 {
     public:
@@ -353,6 +359,8 @@ class traverse_csa_wt
         typedef typename t_csa::char_type char_type;
         typedef typename t_csa::difference_type difference_type;
         typedef random_access_const_iterator<traverse_csa_wt> const_iterator;
+        typedef csa_member_tag                                category;
+        typedef int_alphabet_tag                              alphabet_category;
     private:
         const t_csa& m_csa; //<- pointer to the (compressed) suffix array that is based on a wavelet tree
         traverse_csa_wt() {};    // disable default constructor
@@ -392,7 +400,7 @@ class traverse_csa_wt
         }
 };
 
-template<class t_csa>
+template<typename t_csa>
 class bwt_of_csa_wt
 {
     public:
@@ -401,6 +409,8 @@ class bwt_of_csa_wt
         typedef typename t_csa::char_type char_type;
         typedef typename t_csa::difference_type difference_type;
         typedef random_access_const_iterator<bwt_of_csa_wt> const_iterator;
+        typedef csa_member_tag                              category;
+        typedef typename t_csa::alphabet_category           alphabet_category;
     private:
         const t_csa& m_csa; //<- pointer to the (compressed) suffix array that is based on a wavelet tree
         bwt_of_csa_wt() {};    // disable default constructor
@@ -467,7 +477,7 @@ class bwt_of_csa_wt
         }
 };
 
-template<class t_csa>
+template<typename t_csa>
 class isa_of_csa_wt
 {
     public:
@@ -475,6 +485,8 @@ class isa_of_csa_wt
         typedef typename t_csa::size_type size_type;
         typedef typename t_csa::difference_type difference_type;
         typedef random_access_const_iterator<isa_of_csa_wt> const_iterator;
+        typedef csa_member_tag                              category;
+        typedef int_alphabet_tag                            alphabet_category;
     private:
         const t_csa& m_csa; //<- pointer to the (compressed) suffix array that is based on a wavelet tree
         isa_of_csa_wt() {};    // disable default constructor
@@ -523,7 +535,7 @@ class isa_of_csa_wt
         }
 };
 
-template<class t_csa>
+template<typename t_csa>
 class isa_of_csa_psi
 {
     public:
@@ -531,6 +543,8 @@ class isa_of_csa_psi
         typedef typename t_csa::size_type size_type;
         typedef typename t_csa::difference_type difference_type;
         typedef random_access_const_iterator<isa_of_csa_psi> const_iterator;
+        typedef csa_member_tag                               category;
+        typedef int_alphabet_tag                             alphabet_category;
     private:
         const t_csa& m_csa; //<- pointer to the (compressed) suffix array that is based on a wavelet tree
         isa_of_csa_psi() {};    // disable default constructor
@@ -575,7 +589,7 @@ class isa_of_csa_psi
         }
 };
 
-template<class t_csa>
+template<typename t_csa>
 class first_row_of_csa
 {
     public:
@@ -583,6 +597,8 @@ class first_row_of_csa
         typedef typename t_csa::size_type size_type;
         typedef typename t_csa::difference_type difference_type;
         typedef random_access_const_iterator<first_row_of_csa> const_iterator;
+        typedef csa_member_tag                                 category;
+        typedef typename t_csa::alphabet_category              alphabet_category;
     private:
         const t_csa& m_csa;
     public:
@@ -621,7 +637,7 @@ class first_row_of_csa
 };
 
 
-template<class t_csa>
+template<typename t_csa>
 class text_of_csa
 {
     public:
@@ -629,6 +645,8 @@ class text_of_csa
         typedef typename t_csa::size_type size_type;
         typedef typename t_csa::difference_type difference_type;
         typedef random_access_const_iterator<text_of_csa> const_iterator;
+        typedef csa_member_tag                            category;
+        typedef typename t_csa::alphabet_category         alphabet_category;
     private:
         const t_csa& m_csa;
         text_of_csa() {}

--- a/lib/io.cpp
+++ b/lib/io.cpp
@@ -67,7 +67,7 @@ uint64_t _parse_number(std::string::const_iterator& c, const std::string::const_
     std::string::const_iterator s = c;
     while (c != end and isdigit(*c)) ++c;
     if (c > s) {
-        return stoull(std::string(s,c));
+        return std::stoull(std::string(s,c));
     } else {
         return 0;
     }

--- a/test/CsaIntTest.cpp
+++ b/test/CsaIntTest.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <vector>
 #include <string>
+#include <algorithm>
 
 namespace
 {
@@ -154,6 +155,11 @@ TYPED_TEST(CsaIntTest, TextAccess)
         auto ex_text = extract(csa, 0, len-1);
         for (size_type j=0; j<len; ++j) {
             ASSERT_EQ(text[j], ex_text[j])<<" j="<<j;
+        }
+        if ( n > 0 ){
+            auto c_out_of_range = (*std::max_element(text.begin(), text.end()))+1;
+            auto cnt = count(csa, {c_out_of_range});
+            ASSERT_EQ(0ULL, cnt) << " c_out_of_range="<<c_out_of_range<<" text="<<csa.text; 
         }
     }
 }


### PR DESCRIPTION
char2comp now checks if the character is in the alphabet.
The std:: namespace prefix was also added in the io.hpp
for stoull (see issue #212).
