### PR TITLE
Add iterator based constructor to sd-vector

### DIFF
--- a/test/BitVectorTest.cpp
+++ b/test/BitVectorTest.cpp
@@ -109,6 +109,25 @@ TYPED_TEST(BitVectorTest, Swap)
     }
 }
 
+TEST(SD_VECTOR, IteratorConstructor)
+{
+    std::vector<uint64_t> pos;
+    bit_vector bv(100000);
+    std::mt19937_64 rng;
+    std::uniform_int_distribution<uint64_t> distribution(0, 9);
+    auto dice = bind(distribution, rng);
+    for (size_t i=0; i < bv.size(); ++i) {
+        if (0 == dice()) {
+            pos.emplace_back(i);
+            bv[i] = 1;
+        }
+    }
+    sd_vector<> sdv(pos.begin(),pos.end());
+    for (size_t i=0; i < bv.size(); ++i) {
+        ASSERT_EQ(sdv[i],bv[i]);
+    }
+}
+
 }// end namespace
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This adds the iterator based constructor to the sd-vector which has been available via a special branch already for a while. I'm using this functionality now so it would be nice to have it in the main repo.
