### PR TITLE
Update use-a-wavelet-tree.cpp

### DIFF
--- a/tutorial/use-a-wavelet-tree.cpp
+++ b/tutorial/use-a-wavelet-tree.cpp
@@ -7,7 +7,7 @@ using namespace std;
 int main(int argc, char* argv[])
 {
     if (argc < 2) {
-        cout << "Usage: " << argv[1] << " file" << endl;
+        cout << "Usage: " << argv[0] << " file" << endl;
         return 1;
     }
     wt_huff<rrr_vector<63>> wt;


### PR DESCRIPTION
argv[0] should be printed rather than argv[1] - Possibly include some example file too?