### PR TITLE
Make cache config more flexible

### DIFF
--- a/lib/io.cpp
+++ b/lib/io.cpp
@@ -75,6 +75,9 @@ uint64_t _parse_number(std::string::const_iterator& c, const std::string::const_
 
 std::string cache_file_name(const std::string& key, const cache_config& config)
 {
+    if (config.file_map.count(key) != 0) {
+        return config.file_map.at(key);
+    }
     return config.dir+"/"+key+"_"+config.id+".sdsl";
 }
 


### PR DESCRIPTION
This commit adds a small tweak to the way the cache config
works in sdsl. Specifically, if a specific file name is stored
in the filemap within a cache config, when calling cache_file_name,
the prestored file is used instead of the standard one. So, if
custom file locations for things like the SA or BWT are now
possible.

This should have no effect on other parts of the library.