### PR TITLE
Add support for bitpattern `00` and `11`

### DIFF
--- a/include/sdsl/bit_vector_il.hpp
+++ b/include/sdsl/bit_vector_il.hpp
@@ -84,7 +84,8 @@ class bit_vector_il
         int_vector<64> m_rank_samples;//!< Space for additional rank samples
 
         // precondition: m_rank_samples.size() <= m_superblocks
-        void init_rank_samples() {
+        void init_rank_samples()
+        {
             uint32_t blockSize_U64 = bits::hi(t_bs>>6);
             size_type idx = 0;
             std::queue<size_type> lbs, rbs;
@@ -109,7 +110,8 @@ class bit_vector_il
         bit_vector_il& operator=(const bit_vector_il&) = default;
         bit_vector_il& operator=(bit_vector_il&&) = default;
 
-        bit_vector_il(const bit_vector& bv) {
+        bit_vector_il(const bit_vector& bv)
+        {
             m_size = bv.size();
             /* calculate the number of superblocks */
 //          each block of size > 0 gets suberblock in which we store the cumulative sum up to this block
@@ -156,7 +158,8 @@ class bit_vector_il
          *  \par Time complexity
          *     \f$ \Order{1} \f$
          */
-        value_type operator[](size_type i)const {
+        value_type operator[](size_type i)const
+        {
             assert(i < m_size);
             size_type bs = i >> m_block_shift;
             size_type block = bs + (i>>6) + 1;
@@ -171,7 +174,8 @@ class bit_vector_il
          *  \pre idx+len-1 in [0..size()-1]
          *  \pre len in [1..64]
          */
-        uint64_t get_int(size_type idx, uint8_t len=64)const {
+        uint64_t get_int(size_type idx, uint8_t len=64)const
+        {
             assert(idx+len-1 < m_size);
             size_type bs = idx >> m_block_shift;
             size_type b_block = bs + (idx>>6) + 1;
@@ -187,12 +191,14 @@ class bit_vector_il
         }
 
         //! Returns the size of the original bit vector.
-        size_type size()const {
+        size_type size()const
+        {
             return m_size;
         }
 
         //! Serializes the data structure into the given ostream
-        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const
+        {
             structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
             size_type written_bytes = 0;
             written_bytes += write_member(m_size, out, child, "size");
@@ -206,7 +212,8 @@ class bit_vector_il
         }
 
         //! Loads the data structure from the given istream.
-        void load(std::istream& in) {
+        void load(std::istream& in)
+        {
             read_member(m_size, in);
             read_member(m_block_num, in);
             read_member(m_superblocks, in);
@@ -215,7 +222,8 @@ class bit_vector_il
             m_rank_samples.load(in);
         }
 
-        void swap(bit_vector_il& bv) {
+        void swap(bit_vector_il& bv)
+        {
             if (this != &bv) {
                 std::swap(m_size, bv.m_size);
                 std::swap(m_block_num, bv.m_block_num);
@@ -226,11 +234,13 @@ class bit_vector_il
             }
         }
 
-        iterator begin() const {
+        iterator begin() const
+        {
             return iterator(this, 0);
         }
 
-        iterator end() const {
+        iterator end() const
+        {
             return iterator(this, size());
         }
 };
@@ -243,13 +253,15 @@ class rank_support_il
         typedef bit_vector::size_type size_type;
         typedef bit_vector_il<t_bs>   bit_vector_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = (uint8_t)1 };
     private:
         const bit_vector_type* m_v;
         size_type m_block_shift;
         size_type m_block_mask;
         size_type m_block_size_U64;  //! Size of superblocks in 64-bit words
 
-        inline size_type rank1(size_type i) const {
+        inline size_type rank1(size_type i) const
+        {
             size_type SBlockNum = i >> m_block_shift;
             size_type SBlockPos = (SBlockNum << m_block_size_U64) + SBlockNum;
             uint64_t resp = m_v->m_data[SBlockPos];
@@ -265,7 +277,8 @@ class rank_support_il
         }
 
 
-        inline size_type rank0(size_type i) const {
+        inline size_type rank0(size_type i) const
+        {
             size_type SBlockNum = i >> m_block_shift;
             size_type SBlockPos = (SBlockNum << m_block_size_U64) + SBlockNum;
             uint64_t resp = (SBlockNum << m_block_shift) - m_v->m_data[SBlockPos];
@@ -282,7 +295,8 @@ class rank_support_il
 
     public:
 
-        rank_support_il(const bit_vector_type* v=nullptr) {
+        rank_support_il(const bit_vector_type* v=nullptr)
+        {
             set_vector(v);
             m_block_shift = bits::hi(t_bs);
             m_block_mask = t_bs - 1;
@@ -290,24 +304,29 @@ class rank_support_il
         }
 
         //! Returns the position of the i-th occurrence in the bit vector.
-        size_type rank(size_type i) const {
+        size_type rank(size_type i) const
+        {
             if (t_b) return rank1(i);
             return rank0(i);
         }
 
-        size_type operator()(size_type i)const {
+        size_type operator()(size_type i)const
+        {
             return rank(i);
         }
 
-        size_type size()const {
+        size_type size()const
+        {
             return m_v->size();
         }
 
-        void set_vector(const bit_vector_type* v=nullptr) {
+        void set_vector(const bit_vector_type* v=nullptr)
+        {
             m_v = v;
         }
 
-        rank_support_il& operator=(const rank_support_il& rs) {
+        rank_support_il& operator=(const rank_support_il& rs)
+        {
             if (this != &rs) {
                 set_vector(rs.m_v);
             }
@@ -316,11 +335,13 @@ class rank_support_il
 
         void swap(rank_support_il&) { }
 
-        void load(std::istream&, const bit_vector_type* v=nullptr) {
+        void load(std::istream&, const bit_vector_type* v=nullptr)
+        {
             set_vector(v);
         }
 
-        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const
+        {
             return serialize_empty_object(out, v, name, this);
         }
 };
@@ -334,6 +355,7 @@ class select_support_il
         typedef bit_vector::size_type size_type;
         typedef bit_vector_il<t_bs>   bit_vector_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = (uint8_t)1 };
     private:
         const bit_vector_type* m_v;
         size_type m_superblocks;
@@ -341,7 +363,8 @@ class select_support_il
         size_type m_block_size_U64;
 
         //! Returns the position of the i-th occurrence in the bit vector.
-        size_type select1(size_type i) const {
+        size_type select1(size_type i) const
+        {
             size_type lb = 0, rb = m_v->m_superblocks; // search interval [lb..rb)
             size_type res = 0;
             size_type idx = 0; // index in m_rank_samples
@@ -390,7 +413,8 @@ class select_support_il
         }
 
         //! Returns the position of the i-th occurrence in the bit vector.
-        size_type select0(size_type i)const {
+        size_type select0(size_type i)const
+        {
             size_type lb = 0, rb = m_v->m_superblocks; // search interval [lb..rb)
             size_type res = 0;
             size_type idx = 0; // index in m_rank_samples
@@ -441,7 +465,8 @@ class select_support_il
 
     public:
 
-        select_support_il(const bit_vector_type* v=nullptr) {
+        select_support_il(const bit_vector_type* v=nullptr)
+        {
             set_vector(v);
             m_block_shift = bits::hi(t_bs);
             m_block_size_U64 = bits::hi(t_bs>>6);
@@ -449,24 +474,29 @@ class select_support_il
         }
 
         //! Returns the position of the i-th occurrence in the bit vector.
-        size_type select(size_type i) const {
+        size_type select(size_type i) const
+        {
             if (t_b) return select1(i);
             return select0(i);
         }
 
-        size_type operator()(size_type i)const {
+        size_type operator()(size_type i)const
+        {
             return select(i);
         }
 
-        size_type size()const {
+        size_type size()const
+        {
             return m_v->size();
         }
 
-        void set_vector(const bit_vector_type* v=nullptr) {
+        void set_vector(const bit_vector_type* v=nullptr)
+        {
             m_v = v;
         }
 
-        select_support_il& operator=(const select_support_il& rs) {
+        select_support_il& operator=(const select_support_il& rs)
+        {
             if (this != &rs) {
                 set_vector(rs.m_v);
             }
@@ -475,11 +505,13 @@ class select_support_il
 
         void swap(select_support_il&) { }
 
-        void load(std::istream&, const bit_vector_type* v=nullptr) {
+        void load(std::istream&, const bit_vector_type* v=nullptr)
+        {
             set_vector(v);
         }
 
-        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const
+        {
             return serialize_empty_object(out, v, name, this);
         }
 };

--- a/include/sdsl/bits.hpp
+++ b/include/sdsl/bits.hpp
@@ -157,7 +157,7 @@ struct bits {
     //! Map all 10 bit pairs to 01 or 1 if c=1 and the lsb=0. All other pairs are mapped to 00.
     static uint64_t map10(uint64_t x, uint64_t c=0);
 
-    //! Map all 01 bit pairs to 01 of 1 if c=1 and the lsb=0. All other pairs are mapped to 00.
+    //! Map all 01 bit pairs to 01 or 1 if c=1 and the lsb=0. All other pairs are mapped to 00.
     static uint64_t map01(uint64_t x, uint64_t c=1);
 
     //! Calculate the position of the i-th rightmost 1 bit in the 64bit integer x

--- a/include/sdsl/hyb_vector.hpp
+++ b/include/sdsl/hyb_vector.hpp
@@ -632,6 +632,7 @@ class rank_support_hyb
         typedef hyb_vector<k_sblock_rate> bit_vector_type;
         typedef typename bit_vector_type::size_type size_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = (uint8_t)1 };
     private:
         const bit_vector_type* m_v;
 
@@ -832,6 +833,7 @@ class select_support_hyb
         typedef hyb_vector<k_sblock_rate> bit_vector_type;
         typedef typename bit_vector_type::size_type size_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = (uint8_t)1 };
     private:
         const bit_vector_type* m_v;
 

--- a/include/sdsl/rank_support_scan.hpp
+++ b/include/sdsl/rank_support_scan.hpp
@@ -41,37 +41,46 @@ template<uint8_t t_b=1, uint8_t t_pat_len=1>
 class rank_support_scan : public rank_support
 {
     private:
-        static_assert(t_b == 1u or t_b == 0u or t_b == 10u , "rank_support_scan: bit pattern must be `0`,`1`,`10` or `01`");
+        static_assert(t_b == 1u or t_b == 0u or t_b == 10u or t_b == 11u, "rank_support_scan: bit pattern must be `0`,`1`,`10` or `01`");
         static_assert(t_pat_len == 1u or t_pat_len == 2u , "rank_support_scan: bit pattern length must be 1 or 2");
     public:
         typedef bit_vector bit_vector_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = t_pat_len };
     public:
-        explicit rank_support_scan(const bit_vector* v = nullptr) {
+        explicit rank_support_scan(const bit_vector* v = nullptr)
+        {
             set_vector(v);
         }
-        rank_support_scan(const rank_support_scan& rs) {
+        rank_support_scan(const rank_support_scan& rs)
+        {
             set_vector(rs.m_v);
         }
         size_type rank(size_type idx) const;
-        size_type operator()(size_type idx)const {
+        size_type operator()(size_type idx)const
+        {
             return rank(idx);
         };
-        size_type size()const {
+        size_type size()const
+        {
             return m_v->size();
         };
-        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const
+        {
             return serialize_empty_object(out, v, name, this);
         }
-        void load(std::istream&, const int_vector<1>* v=nullptr) {
+        void load(std::istream&, const int_vector<1>* v=nullptr)
+        {
             set_vector(v);
         }
-        void set_vector(const bit_vector* v=nullptr) {
+        void set_vector(const bit_vector* v=nullptr)
+        {
             m_v=v;
         }
 
         //! Assign Operator
-        rank_support_scan& operator=(const rank_support_scan& rs) {
+        rank_support_scan& operator=(const rank_support_scan& rs)
+        {
             set_vector(rs.m_v);
             return *this;
         }

--- a/include/sdsl/rank_support_v.hpp
+++ b/include/sdsl/rank_support_v.hpp
@@ -53,17 +53,19 @@ template<uint8_t t_b=1, uint8_t t_pat_len=1>
 class rank_support_v : public rank_support
 {
     private:
-        static_assert(t_b == 1u or t_b == 0u or t_b == 10u , "rank_support_v: bit pattern must be `0`,`1`,`10` or `01`");
+        static_assert(t_b == 1u or t_b == 0u or t_b == 10u or t_b == 11, "rank_support_v: bit pattern must be `0`,`1`,`10` or `01`");
         static_assert(t_pat_len == 1u or t_pat_len == 2u , "rank_support_v: bit pattern length must be 1 or 2");
     public:
         typedef bit_vector                          bit_vector_type;
         typedef rank_support_trait<t_b, t_pat_len>  trait_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = t_pat_len };
     private:
         // basic block for interleaved storage of superblockrank and blockrank
         int_vector<64> m_basic_block;
     public:
-        explicit rank_support_v(const bit_vector* v = nullptr) {
+        explicit rank_support_v(const bit_vector* v = nullptr)
+        {
             set_vector(v);
             if (v == nullptr) {
                 return;
@@ -110,7 +112,8 @@ class rank_support_v : public rank_support
         rank_support_v& operator=(rank_support_v&&) = default;
 
 
-        size_type rank(size_type idx) const {
+        size_type rank(size_type idx) const
+        {
             assert(m_v != nullptr);
             assert(idx <= m_v->size());
             const uint64_t* p = m_basic_block.data()
@@ -122,16 +125,19 @@ class rank_support_v : public rank_support
                 return  *p + ((*(p+1)>>(63 - 9*((idx&0x1FF)>>6)))&0x1FF);
         }
 
-        inline size_type operator()(size_type idx)const {
+        inline size_type operator()(size_type idx)const
+        {
             return rank(idx);
         }
 
-        size_type size()const {
+        size_type size()const
+        {
             return m_v->size();
         }
 
         size_type serialize(std::ostream& out, structure_tree_node* v=nullptr,
-                            std::string name="")const {
+                            std::string name="")const
+        {
             size_type written_bytes = 0;
             structure_tree_node* child = structure_tree::add_child(v, name,
                                          util::class_name(*this));
@@ -141,16 +147,19 @@ class rank_support_v : public rank_support
             return written_bytes;
         }
 
-        void load(std::istream& in, const int_vector<1>* v=nullptr) {
+        void load(std::istream& in, const int_vector<1>* v=nullptr)
+        {
             set_vector(v);
             m_basic_block.load(in);
         }
 
-        void set_vector(const bit_vector* v=nullptr) {
+        void set_vector(const bit_vector* v=nullptr)
+        {
             m_v = v;
         }
 
-        void swap(rank_support_v& rs) {
+        void swap(rank_support_v& rs)
+        {
             if (this != &rs) { // if rs and _this_ are not the same object
                 m_basic_block.swap(rs.m_basic_block);
             }

--- a/include/sdsl/rank_support_v5.hpp
+++ b/include/sdsl/rank_support_v5.hpp
@@ -51,17 +51,19 @@ template<uint8_t t_b=1, uint8_t t_pat_len=1>
 class rank_support_v5 : public rank_support
 {
     private:
-        static_assert(t_b == 1u or t_b == 0u or t_b == 10u , "rank_support_v5: bit pattern must be `0`,`1`,`10` or `01`");
+        static_assert(t_b == 1u or t_b == 0u or t_b == 10u or t_b == 11u, "rank_support_v5: bit pattern must be `0`,`1`,`10` or `01` or `11`");
         static_assert(t_pat_len == 1u or t_pat_len == 2u , "rank_support_v5: bit pattern length must be 1 or 2");
     public:
         typedef bit_vector bit_vector_type;
         typedef rank_support_trait<t_b, t_pat_len>  trait_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = t_pat_len };
     private:
 //      basic block for interleaved storage of superblockrank and blockrank
         int_vector<64> m_basic_block;
     public:
-        explicit rank_support_v5(const bit_vector* v = nullptr) {
+        explicit rank_support_v5(const bit_vector* v = nullptr)
+        {
             set_vector(v);
             if (v == nullptr) {
                 return;
@@ -112,7 +114,8 @@ class rank_support_v5 : public rank_support
         rank_support_v5& operator=(const rank_support_v5&) = default;
         rank_support_v5& operator=(rank_support_v5&&) = default;
 
-        size_type rank(size_type idx) const {
+        size_type rank(size_type idx) const
+        {
             assert(m_v != nullptr);
             assert(idx <= m_v->size());
             const uint64_t* p = m_basic_block.data()
@@ -132,14 +135,17 @@ class rank_support_v5 : public rank_support
             return result;
         }
 
-        inline size_type operator()(size_type idx)const {
+        inline size_type operator()(size_type idx)const
+        {
             return rank(idx);
         }
-        size_type size()const {
+        size_type size()const
+        {
             return m_v->size();
         }
 
-        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const
+        {
             size_type written_bytes = 0;
             structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
             written_bytes += m_basic_block.serialize(out, child, "cumulative_counts");
@@ -147,17 +153,20 @@ class rank_support_v5 : public rank_support
             return written_bytes;
         }
 
-        void load(std::istream& in, const bit_vector* v=nullptr) {
+        void load(std::istream& in, const bit_vector* v=nullptr)
+        {
             set_vector(v);
             assert(m_v != nullptr); // supported bit vector should be known
             m_basic_block.load(in);
         }
 
-        void set_vector(const bit_vector* v=nullptr) {
+        void set_vector(const bit_vector* v=nullptr)
+        {
             m_v = v;
         }
         //! swap Operator
-        void swap(rank_support_v5& rs) {
+        void swap(rank_support_v5& rs)
+        {
             if (this != &rs) { // if rs and _this_ are not the same object
                 m_basic_block.swap(rs.m_basic_block);
             }

--- a/include/sdsl/rrr_vector.hpp
+++ b/include/sdsl/rrr_vector.hpp
@@ -107,7 +107,8 @@ class rrr_vector
         // have to be considered as inverted i.e. 1 and
         // 0 are swapped
 
-        void copy(const rrr_vector& rrr) {
+        void copy(const rrr_vector& rrr)
+        {
             m_size = rrr.m_size;
             m_bt = rrr.m_bt;
             m_btnr = rrr.m_btnr;
@@ -124,7 +125,8 @@ class rrr_vector
         rrr_vector() {};
 
         //! Copy constructor
-        rrr_vector(const rrr_vector& rrr) {
+        rrr_vector(const rrr_vector& rrr)
+        {
             copy(rrr);
         }
 
@@ -139,7 +141,8 @@ class rrr_vector
         *  \param bv  Uncompressed bitvector.
         *  \param k   Store rank samples and pointers each k-th blocks.
         */
-        rrr_vector(const bit_vector& bv) {
+        rrr_vector(const bit_vector& bv)
+        {
             m_size = bv.size();
             int_vector<> bt_array;
             bt_array.width(bits::hi(t_bs)+1);
@@ -233,7 +236,8 @@ class rrr_vector
         }
 
         //! Swap method
-        void swap(rrr_vector& rrr) {
+        void swap(rrr_vector& rrr)
+        {
             if (this != &rrr) {
                 std::swap(m_size, rrr.m_size);
                 m_bt.swap(rrr.m_bt);
@@ -248,7 +252,8 @@ class rrr_vector
         /*! \param i An index i with \f$ 0 \leq i < size()  \f$.
            \return The i-th bit of the original bit_vector
         */
-        value_type operator[](size_type i)const {
+        value_type operator[](size_type i)const
+        {
             size_type bt_idx = i/t_bs;
             uint16_t bt = m_bt[bt_idx];
             size_type sample_pos = bt_idx/t_k;
@@ -277,7 +282,8 @@ class rrr_vector
          *  \pre idx+len-1 in [0..size()-1]
          *  \pre len in [1..64]
          */
-        uint64_t get_int(size_type idx, uint8_t len=64)const {
+        uint64_t get_int(size_type idx, uint8_t len=64)const
+        {
             uint64_t res = 0;
             size_type bb_idx = idx/t_bs; // begin block index
             size_type bb_off = idx%t_bs; // begin block offset
@@ -316,7 +322,8 @@ class rrr_vector
         }
 
         //! Assignment operator
-        rrr_vector& operator=(const rrr_vector& rrr) {
+        rrr_vector& operator=(const rrr_vector& rrr)
+        {
             if (this != &rrr) {
                 copy(rrr);
             }
@@ -324,19 +331,22 @@ class rrr_vector
         }
 
         //! Move assignment operator
-        rrr_vector& operator=(rrr_vector&& rrr) {
+        rrr_vector& operator=(rrr_vector&& rrr)
+        {
             swap(rrr);
             return *this;
         }
 
         //! Returns the size of the original bit vector.
-        size_type size()const {
+        size_type size()const
+        {
             return m_size;
         }
 
         //! Answers select queries
         //! Serializes the data structure into the given ostream
-        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const
+        {
             structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
             size_type written_bytes = 0;
             written_bytes += write_member(m_size, out, child, "size");
@@ -350,7 +360,8 @@ class rrr_vector
         }
 
         //! Loads the data structure from the given istream.
-        void load(std::istream& in) {
+        void load(std::istream& in)
+        {
             read_member(m_size, in);
             m_bt.load(in);
             m_btnr.load(in);
@@ -359,11 +370,13 @@ class rrr_vector
             m_invert.load(in);
         }
 
-        iterator begin() const {
+        iterator begin() const
+        {
             return iterator(this, 0);
         }
 
-        iterator end() const {
+        iterator end() const
+        {
             return iterator(this, size());
         }
 };
@@ -371,7 +384,8 @@ class rrr_vector
 template<uint8_t t_bit_pattern>
 struct rank_support_rrr_trait {
     typedef bit_vector::size_type size_type;
-    static size_type adjust_rank(size_type r, SDSL_UNUSED size_type n) {
+    static size_type adjust_rank(size_type r, SDSL_UNUSED size_type n)
+    {
         return r;
     }
 };
@@ -379,7 +393,8 @@ struct rank_support_rrr_trait {
 template<>
 struct rank_support_rrr_trait<0> {
     typedef bit_vector::size_type size_type;
-    static size_type adjust_rank(size_type r, size_type n) {
+    static size_type adjust_rank(size_type r, size_type n)
+    {
         return n - r;
     }
 };
@@ -405,6 +420,7 @@ class rank_support_rrr
         typedef typename bit_vector_type::rrr_helper_type rrr_helper_type;
         typedef typename rrr_helper_type::number_type number_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = (uint8_t)1 };
 
     private:
         const bit_vector_type* m_v; //!< Pointer to the rank supported rrr_vector
@@ -413,7 +429,8 @@ class rank_support_rrr
         //! Standard constructor
         /*! \param v Pointer to the rrr_vector, which should be supported
          */
-        explicit rank_support_rrr(const bit_vector_type* v=nullptr) {
+        explicit rank_support_rrr(const bit_vector_type* v=nullptr)
+        {
             set_vector(v);
         }
 
@@ -423,7 +440,8 @@ class rank_support_rrr
            \par Time complexity
                 \f$ \Order{ sample\_rate of the rrr\_vector} \f$
         */
-        const size_type rank(size_type i)const {
+        const size_type rank(size_type i)const
+        {
             assert(m_v != nullptr);
             assert(i <= m_v->size());
             size_type bt_idx = i/t_bs;
@@ -461,21 +479,25 @@ class rank_support_rrr
         }
 
         //! Short hand for rank(i)
-        const size_type operator()(size_type i)const {
+        const size_type operator()(size_type i)const
+        {
             return rank(i);
         }
 
         //! Returns the size of the original vector
-        const size_type size()const {
+        const size_type size()const
+        {
             return m_v->size();
         }
 
         //! Set the supported vector.
-        void set_vector(const bit_vector_type* v=nullptr) {
+        void set_vector(const bit_vector_type* v=nullptr)
+        {
             m_v = v;
         }
 
-        rank_support_rrr& operator=(const rank_support_rrr& rs) {
+        rank_support_rrr& operator=(const rank_support_rrr& rs)
+        {
             if (this != &rs) {
                 set_vector(rs.m_v);
             }
@@ -485,12 +507,14 @@ class rank_support_rrr
         void swap(rank_support_rrr&) { }
 
         //! Load the data structure from a stream and set the supported vector.
-        void load(std::istream&, const bit_vector_type* v=nullptr) {
+        void load(std::istream&, const bit_vector_type* v=nullptr)
+        {
             set_vector(v);
         }
 
         //! Serializes the data structure into a stream.
-        size_type serialize(std::ostream&, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream&, structure_tree_node* v=nullptr, std::string name="")const
+        {
             structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
             structure_tree::add_size(child, 0);
             return 0;
@@ -519,10 +543,12 @@ class select_support_rrr
         typedef typename bit_vector_type::rrr_helper_type rrr_helper_type;
         typedef typename rrr_helper_type::number_type number_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = (uint8_t)1 };
     private:
         const bit_vector_type* m_v; //!< Pointer to the rank supported rrr_vector
 
-        size_type select1(size_type i)const {
+        size_type select1(size_type i)const
+        {
             if (m_v->m_rank[m_v->m_rank.size()-1] < i)
                 return size();
             //  (1) binary search for the answer in the rank_samples
@@ -561,7 +587,8 @@ class select_support_rrr
             return (idx-1) * t_bs + rrr_helper_type::decode_select(bt, btnr, i-rank);
         }
 
-        size_type select0(size_type i)const {
+        size_type select0(size_type i)const
+        {
             if ((size() - m_v->m_rank[m_v->m_rank.size()-1]) < i) {
                 return size();
             }
@@ -601,28 +628,34 @@ class select_support_rrr
 
 
     public:
-        explicit select_support_rrr(const bit_vector_type* v=nullptr) {
+        explicit select_support_rrr(const bit_vector_type* v=nullptr)
+        {
             set_vector(v);
         }
 
         //! Answers select queries
-        size_type select(size_type i)const {
+        size_type select(size_type i)const
+        {
             return  t_b ? select1(i) : select0(i);
         }
 
-        const size_type operator()(size_type i)const {
+        const size_type operator()(size_type i)const
+        {
             return select(i);
         }
 
-        const size_type size()const {
+        const size_type size()const
+        {
             return m_v->size();
         }
 
-        void set_vector(const bit_vector_type* v=nullptr) {
+        void set_vector(const bit_vector_type* v=nullptr)
+        {
             m_v = v;
         }
 
-        select_support_rrr& operator=(const select_support_rrr& rs) {
+        select_support_rrr& operator=(const select_support_rrr& rs)
+        {
             if (this != &rs) {
                 set_vector(rs.m_v);
             }
@@ -631,11 +664,13 @@ class select_support_rrr
 
         void swap(select_support_rrr&) { }
 
-        void load(std::istream&, const bit_vector_type* v=nullptr) {
+        void load(std::istream&, const bit_vector_type* v=nullptr)
+        {
             set_vector(v);
         }
 
-        size_type serialize(std::ostream&, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream&, structure_tree_node* v=nullptr, std::string name="")const
+        {
             structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
             structure_tree::add_size(child, 0);
             return 0;

--- a/include/sdsl/rrr_vector_15.hpp
+++ b/include/sdsl/rrr_vector_15.hpp
@@ -58,7 +58,8 @@ class binomial15
                 int_vector<16> m_nr_to_bin;
                 int_vector<16> m_bin_to_nr;
 
-                impl() {
+                impl()
+                {
                     m_nr_to_bin.resize(1<<n);
                     m_bin_to_nr.resize(1<<n);
                     for (int i=0, cnt=0, class_cnt=0; i<=n; ++i) {
@@ -90,19 +91,23 @@ class binomial15
 
     public:
 
-        static inline uint8_t space_for_bt(uint32_t i) {
+        static inline uint8_t space_for_bt(uint32_t i)
+        {
             return iii.m_space_for_bt[i];
         }
 
-        static inline uint32_t nr_to_bin(uint8_t k, uint32_t nr) {
+        static inline uint32_t nr_to_bin(uint8_t k, uint32_t nr)
+        {
             return iii.m_nr_to_bin[iii.m_C[k]+nr];
         }
 
-        static inline uint32_t bin_to_nr(uint32_t bin) {
+        static inline uint32_t bin_to_nr(uint32_t bin)
+        {
             return iii.m_bin_to_nr[bin];
         }
 
-        static inline uint8_t space_for_bt_pair(uint8_t x) {
+        static inline uint8_t space_for_bt_pair(uint8_t x)
+        {
             return iii.m_space_for_bt_pair[x];
         }
 };
@@ -151,7 +156,8 @@ class rrr_vector<15, t_rac, t_k>
         int_vector<> m_btnrp;    // Sample pointers into m_btnr.
         int_vector<> m_rank;     // Sample rank values.
 
-        void copy(const rrr_vector& rrr) {
+        void copy(const rrr_vector& rrr)
+        {
             m_size = rrr.m_size;
             m_bt = rrr.m_bt;
             m_btnr = rrr.m_btnr;
@@ -168,7 +174,8 @@ class rrr_vector<15, t_rac, t_k>
         rrr_vector() {};
 
         //! Copy constructor
-        rrr_vector(const rrr_vector& rrr) {
+        rrr_vector(const rrr_vector& rrr)
+        {
             copy(rrr);
         }
 
@@ -183,7 +190,8 @@ class rrr_vector<15, t_rac, t_k>
         *  \param bv Uncompressed bitvector.
         *  \param k  Store rank samples and pointers each k-th blocks.
         */
-        rrr_vector(const bit_vector& bv) {
+        rrr_vector(const bit_vector& bv)
+        {
             m_size = bv.size();
             int_vector<> bt_array;
             bt_array = int_vector<>(m_size/block_size+1, 0, bits::hi(block_size)+1);
@@ -246,7 +254,8 @@ class rrr_vector<15, t_rac, t_k>
         }
 
         //! Swap method
-        void swap(rrr_vector& rrr) {
+        void swap(rrr_vector& rrr)
+        {
             if (this != &rrr) {
                 std::swap(m_size, rrr.m_size);
                 m_bt.swap(rrr.m_bt);
@@ -260,7 +269,8 @@ class rrr_vector<15, t_rac, t_k>
         /*! \param i An index i with \f$ 0 \leq i < size()  \f$.
            \return The i-th bit of the original bit_vector
         */
-        value_type operator[](size_type i)const {
+        value_type operator[](size_type i)const
+        {
             size_type bt_idx = i/block_size ;
             uint8_t* bt = (uint8_t*)(m_bt.data());
             uint32_t i_bt = *(bt + (bt_idx/2));
@@ -302,7 +312,8 @@ class rrr_vector<15, t_rac, t_k>
          *  \pre idx+len-1 in [0..size()-1]
          *  \pre len in [1..64]
          */
-        uint64_t get_int(size_type idx, uint8_t len=64)const {
+        uint64_t get_int(size_type idx, uint8_t len=64)const
+        {
             uint64_t res = 0;
             size_type bb_idx = idx/block_size; // begin block index
             size_type bb_off = idx%block_size; // begin block offset
@@ -339,7 +350,8 @@ class rrr_vector<15, t_rac, t_k>
 
 
         //! Assignment operator
-        rrr_vector& operator=(const rrr_vector& rrr) {
+        rrr_vector& operator=(const rrr_vector& rrr)
+        {
             if (this != &rrr) {
                 copy(rrr);
             }
@@ -347,18 +359,21 @@ class rrr_vector<15, t_rac, t_k>
         }
 
         //! Move assignment
-        rrr_vector& operator=(rrr_vector&& rrr) {
+        rrr_vector& operator=(rrr_vector&& rrr)
+        {
             swap(rrr);
             return *this;
         }
 
         //! Returns the size of the original bit vector.
-        size_type size()const {
+        size_type size()const
+        {
             return m_size;
         }
 
         //! Serializes the data structure into the given ostream
-        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const
+        {
             size_type written_bytes = 0;
             structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
             written_bytes += write_member(m_size, out, child, "size");
@@ -371,7 +386,8 @@ class rrr_vector<15, t_rac, t_k>
         }
 
         //! Loads the data structure from the given istream.
-        void load(std::istream& in) {
+        void load(std::istream& in)
+        {
             read_member(m_size, in);
             m_bt.load(in);
             m_btnr.load(in);
@@ -379,11 +395,13 @@ class rrr_vector<15, t_rac, t_k>
             m_rank.load(in);
         }
 
-        iterator begin() const {
+        iterator begin() const
+        {
             return iterator(this, 0);
         }
 
-        iterator end() const {
+        iterator end() const
+        {
             return iterator(this, size());
         }
 };
@@ -395,11 +413,13 @@ class rrr_vector<15, t_rac, t_k>
 template<uint8_t t_b, class t_rac, uint16_t t_k>
 class rank_support_rrr<t_b, 15, t_rac, t_k>
 {
+        static_assert(t_b == 1u or t_b == 0u , "rank_support_rrr: bit pattern must be `0` or `1`");
     public:
         typedef rrr_vector<15, t_rac, t_k> bit_vector_type;
         typedef typename bit_vector_type::size_type size_type;
         typedef typename bit_vector_type::bi_type bi_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = (uint8_t)1 };
 
     private:
         const bit_vector_type* m_v; //!< Pointer to the rank supported rrr_vector
@@ -411,7 +431,8 @@ class rank_support_rrr<t_b, 15, t_rac, t_k>
         //! Standard constructor
         /*! \param v Pointer to the rrr_vector, which should be supported
          */
-        explicit rank_support_rrr(const bit_vector_type* v=nullptr) {
+        explicit rank_support_rrr(const bit_vector_type* v=nullptr)
+        {
             set_vector(v);
         }
 
@@ -421,7 +442,8 @@ class rank_support_rrr<t_b, 15, t_rac, t_k>
            \par Time complexity
                 \f$ \Order{ sample\_rate of the rrr\_vector} \f$
         */
-        const size_type rank(size_type i)const {
+        const size_type rank(size_type i)const
+        {
             size_type bt_idx = i/bit_vector_type::block_size;
             size_type sample_pos = bt_idx/t_k;
             size_type btnrp = m_v->m_btnrp[ sample_pos ];
@@ -511,21 +533,25 @@ class rank_support_rrr<t_b, 15, t_rac, t_k>
         }
 
         //! Short hand for rank(i)
-        const size_type operator()(size_type i)const {
+        const size_type operator()(size_type i)const
+        {
             return rank(i);
         }
 
         //! Returns the size of the original vector
-        const size_type size()const {
+        const size_type size()const
+        {
             return m_v->size();
         }
 
         //! Set the supported vector.
-        void set_vector(const bit_vector_type* v=nullptr) {
+        void set_vector(const bit_vector_type* v=nullptr)
+        {
             m_v = v;
         }
 
-        rank_support_rrr& operator=(const rank_support_rrr& rs) {
+        rank_support_rrr& operator=(const rank_support_rrr& rs)
+        {
             if (this != &rs) {
                 set_vector(rs.m_v);
             }
@@ -535,12 +561,14 @@ class rank_support_rrr<t_b, 15, t_rac, t_k>
         void swap(rank_support_rrr&) { }
 
         //! Load the data structure from a stream and set the supported vector.
-        void load(std::istream&, const bit_vector_type* v=nullptr) {
+        void load(std::istream&, const bit_vector_type* v=nullptr)
+        {
             set_vector(v);
         }
 
         //! Serializes the data structure into a stream.
-        size_type serialize(std::ostream&, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream&, structure_tree_node* v=nullptr, std::string name="")const
+        {
             structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
             structure_tree::add_size(child, 0);
             return 0;
@@ -552,16 +580,19 @@ class rank_support_rrr<t_b, 15, t_rac, t_k>
 template<uint8_t t_b, class t_rac, uint16_t t_k>
 class select_support_rrr<t_b, 15, t_rac, t_k>
 {
+        static_assert(t_b == 1u or t_b == 0u , "select_support_rrr: bit pattern must be `0` or `1`");
     public:
         typedef rrr_vector<15, t_rac, t_k>          bit_vector_type;
         typedef typename bit_vector_type::size_type size_type;
         typedef typename bit_vector_type::bi_type     bi_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = (uint8_t)1 };
     private:
         const bit_vector_type* m_v; //!< Pointer to the rank supported rrr_vector
 
         // TODO: hinted binary search
-        size_type  select1(size_type i)const {
+        size_type  select1(size_type i)const
+        {
             if (m_v->m_rank[m_v->m_rank.size()-1] < i)
                 return size();
             //  (1) binary search for the answer in the rank_samples
@@ -598,7 +629,8 @@ class select_support_rrr<t_b, 15, t_rac, t_k>
         }
 
         // TODO: hinted binary search
-        size_type  select0(size_type i)const {
+        size_type  select0(size_type i)const
+        {
             if ((size()-m_v->m_rank[m_v->m_rank.size()-1]) < i)
                 return size();
             //  (1) binary search for the answer in the rank_samples
@@ -636,29 +668,35 @@ class select_support_rrr<t_b, 15, t_rac, t_k>
 
 
     public:
-        select_support_rrr(const bit_vector_type* v=nullptr) {
+        select_support_rrr(const bit_vector_type* v=nullptr)
+        {
             set_vector(v);
         }
 
         //! Answers select queries
-        size_type select(size_type i)const {
+        size_type select(size_type i)const
+        {
             return  t_b ? select1(i) : select0(i);
         }
 
 
-        const size_type operator()(size_type i)const {
+        const size_type operator()(size_type i)const
+        {
             return select(i);
         }
 
-        const size_type size()const {
+        const size_type size()const
+        {
             return m_v->size();
         }
 
-        void set_vector(const bit_vector_type* v=nullptr) {
+        void set_vector(const bit_vector_type* v=nullptr)
+        {
             m_v = v;
         }
 
-        select_support_rrr& operator=(const select_support_rrr& rs) {
+        select_support_rrr& operator=(const select_support_rrr& rs)
+        {
             if (this != &rs) {
                 set_vector(rs.m_v);
             }
@@ -667,11 +705,13 @@ class select_support_rrr<t_b, 15, t_rac, t_k>
 
         void swap(select_support_rrr&) { }
 
-        void load(std::istream&, const bit_vector_type* v=nullptr) {
+        void load(std::istream&, const bit_vector_type* v=nullptr)
+        {
             set_vector(v);
         }
 
-        size_type serialize(std::ostream&, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream&, structure_tree_node* v=nullptr, std::string name="")const
+        {
             structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
             structure_tree::add_size(child, 0);
             return 0;

--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -390,6 +390,7 @@ class rank_support_sd
         typedef bit_vector::size_type size_type;
         typedef sd_vector<t_hi_bit_vector, t_select_1, t_select_0> bit_vector_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = (uint8_t)1 };
     private:
         const bit_vector_type* m_v;
 
@@ -510,7 +511,7 @@ class select_support_sd
         typedef bit_vector::size_type size_type;
         typedef sd_vector<t_hi_bit_vector, t_select_1, t_select_0> bit_vector_type;
         enum { bit_pat = t_b };
-
+        enum { bit_pat_len = (uint8_t)1 };
     private:
         const bit_vector_type* m_v;
     public:
@@ -577,7 +578,7 @@ class select_0_support_sd
         using sel0_type = typename t_sd_vector::select_0_type;
         typedef bit_vector           y_high_type;
         enum { bit_pat = 0 };
-
+        enum { bit_pat_len = (uint8_t)1 };
     private:
         const bit_vector_type* m_v;
         int_vector<>           m_pointer;

--- a/include/sdsl/select_support.hpp
+++ b/include/sdsl/select_support.hpp
@@ -45,7 +45,8 @@ class select_support
         //! Constructor of select_support.
         /*! \param v The bit_vector to support rank queries.
          */
-        select_support(const int_vector<1>* f_v=nullptr):v(f_v) {
+        select_support(const int_vector<1>* f_v=nullptr):v(f_v)
+        {
             m_v = f_v;
         }
         //! Copy constructor
@@ -86,35 +87,43 @@ struct select_support_trait {
     typedef select_support::size_type	size_type;
 
     /* Count the number of arguments for the specific select support */
-    static size_type arg_cnt(const bit_vector&) {
+    static size_type arg_cnt(const bit_vector&)
+    {
         return 0;
     }
 
-    static size_type args_in_the_first_word(uint64_t, uint8_t, uint64_t) {
+    static size_type args_in_the_first_word(uint64_t, uint8_t, uint64_t)
+    {
         return 0;
     }
 
-    static size_type ith_arg_pos_in_the_first_word(uint64_t, size_type, uint8_t, uint64_t) {
+    static size_type ith_arg_pos_in_the_first_word(uint64_t, size_type, uint8_t, uint64_t)
+    {
         return 0;
     }
 
-    static size_type args_in_the_word(uint64_t, uint64_t&) {
+    static size_type args_in_the_word(uint64_t, uint64_t&)
+    {
         return 0;
     }
 
-    static size_type ith_arg_pos_in_the_word(uint64_t, size_type, uint64_t) {
+    static size_type ith_arg_pos_in_the_word(uint64_t, size_type, uint64_t)
+    {
         return 0;
     }
 
-    static bool found_arg(size_type, const bit_vector&) {
+    static bool found_arg(size_type, const bit_vector&)
+    {
         return 0;
     }
 
-    static uint64_t init_carry(const uint64_t*, size_type) {
+    static uint64_t init_carry(const uint64_t*, size_type)
+    {
         return 0;
     }
 
-    static uint64_t get_carry(uint64_t) {
+    static uint64_t get_carry(uint64_t)
+    {
         return 0;
     }
 };
@@ -123,28 +132,36 @@ template<>
 struct select_support_trait<0,1> {
     typedef select_support::size_type	size_type;
 
-    static size_type arg_cnt(const bit_vector& v) {
+    static size_type arg_cnt(const bit_vector& v)
+    {
         return v.bit_size()-util::cnt_one_bits(v);
     }
-    static size_type args_in_the_first_word(uint64_t w, uint8_t offset, uint64_t) {
+    static size_type args_in_the_first_word(uint64_t w, uint8_t offset, uint64_t)
+    {
         return bits::cnt((~w)& bits::lo_unset[offset]);
     }
-    static size_type ith_arg_pos_in_the_first_word(uint64_t w, size_type i, uint8_t offset, uint64_t) {
+    static size_type ith_arg_pos_in_the_first_word(uint64_t w, size_type i, uint8_t offset, uint64_t)
+    {
         return bits::sel(~w & bits::lo_unset[offset], i);
     }
-    static size_type args_in_the_word(uint64_t w, uint64_t&) {
+    static size_type args_in_the_word(uint64_t w, uint64_t&)
+    {
         return bits::cnt(~w);
     }
-    static size_type ith_arg_pos_in_the_word(uint64_t w, size_type i, uint64_t) {
+    static size_type ith_arg_pos_in_the_word(uint64_t w, size_type i, uint64_t)
+    {
         return bits::sel(~w, i);
     }
-    static bool found_arg(size_type i, const bit_vector& v) {
+    static bool found_arg(size_type i, const bit_vector& v)
+    {
         return !v[i];
     }
-    static uint64_t init_carry(const uint64_t*, size_type) {
+    static uint64_t init_carry(const uint64_t*, size_type)
+    {
         return 0;
     }
-    static uint64_t get_carry(uint64_t) {
+    static uint64_t get_carry(uint64_t)
+    {
         return 0;
     }
 };
@@ -153,28 +170,36 @@ template<>
 struct select_support_trait<1,1> {
     typedef select_support::size_type	size_type;
 
-    static size_type arg_cnt(const bit_vector& v) {
+    static size_type arg_cnt(const bit_vector& v)
+    {
         return util::cnt_one_bits(v);
     }
-    static size_type args_in_the_first_word(uint64_t w, uint8_t offset, uint64_t) {
+    static size_type args_in_the_first_word(uint64_t w, uint8_t offset, uint64_t)
+    {
         return bits::cnt(w & bits::lo_unset[offset]);
     }
-    static size_type ith_arg_pos_in_the_first_word(uint64_t w, size_type i, uint8_t offset, uint64_t) {
+    static size_type ith_arg_pos_in_the_first_word(uint64_t w, size_type i, uint8_t offset, uint64_t)
+    {
         return bits::sel(w & bits::lo_unset[offset], i);
     }
-    static size_type args_in_the_word(uint64_t w, uint64_t&) {
+    static size_type args_in_the_word(uint64_t w, uint64_t&)
+    {
         return bits::cnt(w);
     }
-    static size_type ith_arg_pos_in_the_word(uint64_t w, size_type i, uint64_t) {
+    static size_type ith_arg_pos_in_the_word(uint64_t w, size_type i, uint64_t)
+    {
         return bits::sel(w, i);
     }
-    static bool found_arg(size_type i, const bit_vector& v) {
+    static bool found_arg(size_type i, const bit_vector& v)
+    {
         return v[i];
     }
-    static uint64_t init_carry(const uint64_t*, size_type) {
+    static uint64_t init_carry(const uint64_t*, size_type)
+    {
         return 0;
     }
-    static uint64_t get_carry(uint64_t) {
+    static uint64_t get_carry(uint64_t)
+    {
         return 0;
     }
 };
@@ -183,30 +208,38 @@ template<>
 struct select_support_trait<10,2> {
     typedef select_support::size_type	size_type;
 
-    static size_type arg_cnt(const bit_vector& v) {
+    static size_type arg_cnt(const bit_vector& v)
+    {
         return util::cnt_onezero_bits(v);
     }
-    static size_type args_in_the_first_word(uint64_t w, uint8_t offset, uint64_t carry) {
+    static size_type args_in_the_first_word(uint64_t w, uint8_t offset, uint64_t carry)
+    {
         return bits::cnt(bits::map10(w, carry) & bits::lo_unset[offset]);
     }
-    static size_type ith_arg_pos_in_the_first_word(uint64_t w, size_type i, uint8_t offset, uint64_t carry) {
+    static size_type ith_arg_pos_in_the_first_word(uint64_t w, size_type i, uint8_t offset, uint64_t carry)
+    {
         return bits::sel(bits::map10(w, carry) & bits::lo_unset[offset], i);
     }
-    static size_type args_in_the_word(uint64_t w, uint64_t& carry) {
+    static size_type args_in_the_word(uint64_t w, uint64_t& carry)
+    {
         return bits::cnt10(w, carry);
     }
-    static size_type ith_arg_pos_in_the_word(uint64_t w, size_type i, uint64_t carry) {
+    static size_type ith_arg_pos_in_the_word(uint64_t w, size_type i, uint64_t carry)
+    {
         return bits::sel(bits::map10(w, carry), i);
     }
-    static bool found_arg(size_type i, const bit_vector& v) {
+    static bool found_arg(size_type i, const bit_vector& v)
+    {
         if (i > 0 and v[i-1] and !v[i])
             return true;
         return false;
     }
-    static uint64_t init_carry(const uint64_t* data, size_type word_pos) {
+    static uint64_t init_carry(const uint64_t* data, size_type word_pos)
+    {
         return word_pos ? (*(data-1)>>63) : 0;
     }
-    static uint64_t get_carry(uint64_t w) {
+    static uint64_t get_carry(uint64_t w)
+    {
         return w>>63;
     }
 };
@@ -215,30 +248,152 @@ template<>
 struct select_support_trait<01,2> {
     typedef select_support::size_type	size_type;
 
-    static size_type arg_cnt(const bit_vector& v) {
+    static size_type arg_cnt(const bit_vector& v)
+    {
         return util::cnt_zeroone_bits(v);
     }
-    static size_type args_in_the_first_word(uint64_t w, uint8_t offset, uint64_t carry) {
+    static size_type args_in_the_first_word(uint64_t w, uint8_t offset, uint64_t carry)
+    {
         return bits::cnt(bits::map01(w, carry) & bits::lo_unset[offset]);
     }
-    static size_type ith_arg_pos_in_the_first_word(uint64_t w, size_type i, uint8_t offset, uint64_t carry) {
+    static size_type ith_arg_pos_in_the_first_word(uint64_t w, size_type i, uint8_t offset, uint64_t carry)
+    {
         return bits::sel(bits::map01(w, carry) & bits::lo_unset[offset], i);
     }
-    static size_type args_in_the_word(uint64_t w, uint64_t& carry) {
+    static size_type args_in_the_word(uint64_t w, uint64_t& carry)
+    {
         return bits::cnt01(w, carry);
     }
-    static size_type ith_arg_pos_in_the_word(uint64_t w, size_type i, uint64_t carry) {
+    static size_type ith_arg_pos_in_the_word(uint64_t w, size_type i, uint64_t carry)
+    {
         return bits::sel(bits::map01(w, carry), i);
     }
-    static bool found_arg(size_type i, const bit_vector& v) {
-        if (i > 0 and !v[i-1] and v[i])
+    static bool found_arg(size_type i, const bit_vector& v)
+    {
+        return i > 0 and !v[i-1] and v[i];
+    }
+    static uint64_t init_carry(const uint64_t* data, size_type word_pos)
+    {
+        return word_pos ? (*(data-1)>>63) : 1;
+    }
+    static uint64_t get_carry(uint64_t w)
+    {
+        return w>>63;
+    }
+};
+
+template<>
+struct select_support_trait<00,2> {
+    typedef select_support::size_type	size_type;
+
+    static size_type arg_cnt(const bit_vector& v)
+    {
+        const uint64_t* data = v.data();
+        if (v.empty())
+            return 0;
+        uint64_t carry = rank_support_trait<00,2>::init_carry();
+        size_type result = 0;
+        for (auto end = v.data() + (v.size() >> 6); data < end; ++data) {
+            result += rank_support_trait<00,2>::args_in_the_word(*data, carry);
+        }
+        if (v.bit_size()&0x3F) {   // if bit_size is not a multiple of 64, add count of the last word
+            result += rank_support_trait<00,2>::args_in_the_word((*data)|bits::lo_unset[v.bit_size()&0x3F], carry);
+        }
+        return result;
+    }
+
+    static size_type args_in_the_first_word(uint64_t w, uint8_t offset, uint64_t carry)
+    {
+        size_type res = 0;
+        if (offset == 0)
+            res = rank_support_trait<00,2>::args_in_the_word(w, carry);
+        else {
+            res = bits::cnt((~(w | (w<<1))) & bits::lo_unset[offset]);
+        }
+        return res;
+    }
+
+    static size_type ith_arg_pos_in_the_first_word(uint64_t w, size_type i, uint8_t offset, uint64_t carry)
+    {
+        return bits::sel((~(((w << 1) | carry) | w)) & bits::lo_unset[offset], i);
+    }
+    static size_type args_in_the_word(uint64_t w, uint64_t& carry)
+    {
+        return rank_support_trait<00,2>::args_in_the_word(w, carry);
+    }
+    static size_type ith_arg_pos_in_the_word(uint64_t w, size_type i, uint64_t carry)
+    {
+        return bits::sel(~(((w << 1) | carry) | w), i);
+    }
+    static bool found_arg(size_type i, const bit_vector& v)
+    {
+        return i > 0 and !v[i-1] and !v[i];
+    }
+    static uint64_t init_carry(const uint64_t* data, size_type word_pos)
+    {
+        return word_pos ? (*(data-1)>>63) : 1;
+    }
+    static uint64_t get_carry(uint64_t w)
+    {
+        return w>>63;
+    }
+};
+
+template<>
+struct select_support_trait<11,2> {
+    typedef select_support::size_type	size_type;
+
+    static size_type arg_cnt(const bit_vector& v)
+    {
+        const uint64_t* data = v.data();
+        if (v.empty())
+            return 0;
+        uint64_t carry = rank_support_trait<11,2>::init_carry();
+        size_type result = 0;
+        for (auto end = v.data() + (v.size() >> 6); data < end; ++data) {
+            result += rank_support_trait<11,2>::args_in_the_word(*data, carry);
+        }
+        if (v.bit_size()&0x3F) {   // if bit_size is not a multiple of 64, add count of the last word
+            result += rank_support_trait<11,2>::args_in_the_word((*data)&bits::lo_set[v.bit_size()&0x3F], carry);
+        }
+        return result;
+    }
+
+    static size_type args_in_the_first_word(uint64_t w, uint8_t offset, uint64_t carry)
+    {
+        size_type res = 0;
+        if (offset == 0)
+            res = rank_support_trait<11,2>::args_in_the_word(w, carry);
+        else {
+            res = bits::cnt((w>>(offset-1)) & (w>>offset));
+        }
+        return res;
+    }
+
+    static size_type ith_arg_pos_in_the_first_word(uint64_t w, size_type i, uint8_t offset, uint64_t carry)
+    {
+        return bits::sel((((w << 1) | carry) & w) & bits::lo_unset[offset], i);
+    }
+    static size_type args_in_the_word(uint64_t w, uint64_t& carry)
+    {
+        return rank_support_trait<11,2>::args_in_the_word(w, carry);
+    }
+    static size_type ith_arg_pos_in_the_word(uint64_t w, size_type i, uint64_t carry)
+    {
+        return bits::sel(((w << 1) | carry) & w, i);
+    }
+    static bool found_arg(size_type i, const bit_vector& v)
+    {
+        if (i > 0 and v[i-1] and v[i])
             return true;
         return false;
     }
-    static uint64_t init_carry(const uint64_t* data, size_type word_pos) {
-        return word_pos ? (*(data-1)>>63) : 1;
+    static uint64_t init_carry(const uint64_t* data, size_type word_pos)
+    {
+        return word_pos ? (*(data-1)>>63) : 0;
     }
-    static uint64_t get_carry(uint64_t w) {
+    static uint64_t get_carry(uint64_t w)
+    {
         return w>>63;
     }
 };

--- a/include/sdsl/select_support_mcl.hpp
+++ b/include/sdsl/select_support_mcl.hpp
@@ -68,11 +68,12 @@ template<uint8_t t_b=1, uint8_t t_pat_len=1>
 class select_support_mcl : public select_support
 {
     private:
-        static_assert(t_b == 1u or t_b == 0u or t_b == 10u , "select_support_mcl: bit pattern must be `0`,`1`,`10` or `01`");
+        static_assert(t_b == 1u or t_b == 0u or t_b == 10u or t_b == 11u, "select_support_mcl: bit pattern must be `0`,`1`,`10`, `01`, or `11`");
         static_assert(t_pat_len == 1u or t_pat_len == 2u , "select_support_mcl: bit pattern length must be 1 or 2");
     public:
         typedef bit_vector bit_vector_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = t_pat_len };
     private:
         uint32_t m_logn                 = 0,     // \f$ log(size) \f$
                  m_logn2                = 0,     // \f$ log^2(size) \f$

--- a/include/sdsl/select_support_scan.hpp
+++ b/include/sdsl/select_support_scan.hpp
@@ -44,30 +44,36 @@ template<uint8_t t_b=1, uint8_t t_pat_len=1>
 class select_support_scan : public select_support
 {
     private:
-        static_assert(t_b == 1u or t_b == 0u or t_b == 10u , "select_support_scan: bit pattern must be `0`,`1`,`10` or `01`");
+        static_assert(t_b == 1u or t_b == 0u or t_b == 10u or t_b == 11u, "select_support_scan: bit pattern must be `0`,`1`,`10` or `01`");
         static_assert(t_pat_len == 1u or t_pat_len == 2u , "select_support_scan: bit pattern length must be 1 or 2");
     public:
         typedef bit_vector bit_vector_type;
         enum { bit_pat = t_b };
+        enum { bit_pat_len = t_pat_len };
     public:
         explicit select_support_scan(const bit_vector* v=nullptr) : select_support(v) {}
         select_support_scan(const select_support_scan<t_b,t_pat_len>& ss) : select_support(ss.m_v) {}
 
         inline size_type select(size_type i) const;
-        inline size_type operator()(size_type i)const {
+        inline size_type operator()(size_type i)const
+        {
             return select(i);
         }
-        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const
+        {
             return serialize_empty_object(out, v, name, this);
         }
-        void load(std::istream&, SDSL_UNUSED const bit_vector* v=nullptr) {
+        void load(std::istream&, SDSL_UNUSED const bit_vector* v=nullptr)
+        {
             set_vector(v);
         }
 
-        void set_vector(const bit_vector* v=nullptr) {
+        void set_vector(const bit_vector* v=nullptr)
+        {
             m_v = v;
         }
-        select_support_scan<t_b, t_pat_len>& operator=(const select_support_scan& ss) {
+        select_support_scan<t_b, t_pat_len>& operator=(const select_support_scan& ss)
+        {
             set_vector(ss.m_v);
             return *this;
         }

--- a/test/RankSupportTest.cpp
+++ b/test/RankSupportTest.cpp
@@ -53,7 +53,15 @@ typedef Types<rank_support_il<1, 256>,
         rank_support_rrr<0, 129>,
         rank_support_sd<0>,
         rank_support_hyb<1>,
-        rank_support_hyb<0>
+        rank_support_hyb<0>,
+        rank_support_v<10,2>,
+        rank_support_v<01,2>,
+        rank_support_v<00,2>,
+        rank_support_v<11,2>,
+        rank_support_v5<10,2>,
+        rank_support_v5<01,2>,
+        rank_support_v5<00,2>,
+        rank_support_v5<11,2>
         > Implementations;
 
 TYPED_TEST_CASE(RankSupportTest, Implementations);
@@ -69,7 +77,11 @@ TYPED_TEST(RankSupportTest, RankMethod)
     uint64_t rank=0;
     for (uint64_t j=0; j < bvec.size(); ++j) {
         ASSERT_EQ(rank, rs.rank(j));
-        rank += (bvec[j] == TypeParam::bit_pat);
+        bool found = (j >= TypeParam::bit_pat_len-1);
+        for (uint8_t k=0; found and k < TypeParam::bit_pat_len; ++k) {
+            found &= bvec[j-k] == ((TypeParam::bit_pat>>k)&1);
+        }
+        rank += found;
     }
     EXPECT_EQ(rank, rs.rank(bvec.size()));
 }

--- a/test/SelectSupportTest.cpp
+++ b/test/SelectSupportTest.cpp
@@ -41,7 +41,11 @@ typedef Types<select_support_mcl<>,
         select_support_rrr<0, 127>,
         select_support_il<0, 256>,
         select_support_il<0, 512>,
-        select_support_il<0, 1024>
+        select_support_il<0, 1024>,
+        select_support_mcl<01,2>,
+        select_support_mcl<10,2>,
+        select_support_mcl<00,2>,
+        select_support_mcl<11,2>
         > Implementations;
 
 TYPED_TEST_CASE(SelectSupportTest, Implementations);
@@ -55,10 +59,18 @@ TYPED_TEST(SelectSupportTest, SelectMethod)
     typename TypeParam::bit_vector_type bv(bvec);
     TypeParam ss(&bv);
     for (uint64_t j=0, select=0; j < bvec.size(); ++j) {
-        if (bvec[j] == TypeParam::bit_pat) {
+        bool found = (j >= TypeParam::bit_pat_len-1);
+        for (uint8_t k=0; found and k < TypeParam::bit_pat_len; ++k) {
+            found &= bvec[j-k] == ((TypeParam::bit_pat>>k)&1);
+        }
+        if (found) {
             ++select;
             ASSERT_EQ(j, ss.select(select));
         }
+//        if (bvec[j] == TypeParam::bit_pat) {
+//            ++select;
+//            ASSERT_EQ(j, ss.select(select));
+//        }
     }
 }
 


### PR DESCRIPTION
for rank_support_v, rank_support_v5, and select_support_mcl.
Tests were adjusted accordingly.