### PR TITLE
Fixed typo in cheatsheet + added const qualifier

### DIFF
--- a/extras/cheatsheet/sdsl-cheatsheet.tex
+++ b/extras/cheatsheet/sdsl-cheatsheet.tex
@@ -500,7 +500,7 @@ Multi-level pioneer structure.\\
 Min-max-tree over excess sequence.\\
 \end{tabular}
 \textit{Public~methods:} \code{find\_open($i$)}, \code{find\_close($i$)},
-\code{enclode($i$)}, \code{double\_enclose($i$,$j$)}, \code{excess($i$)},
+\code{enclose($i$)}, \code{double\_enclose($i$,$j$)}, \code{excess($i$)},
 \code{rr\_enclose($i$,$j$)}, \code{rank($i$)}\footnote{For PBS the
 bits are counted in the prefix $[0..i]$.}, \code{select($i$)}.
 \\

--- a/include/sdsl/cst_sada.hpp
+++ b/include/sdsl/cst_sada.hpp
@@ -576,15 +576,15 @@ class cst_sada
             }
         }
 
-//! Get the child w of node v which edge label (v,w) starts with character c.
-// \sa child(node_type v, const char_type c, size_type &char_pos)
-        node_type child(node_type v, const char_type c)
+        //! Get the child w of node v which edge label (v,w) starts with character c.
+        // \sa child(node_type v, const char_type c, size_type &char_pos)
+        node_type child(node_type v, const char_type c) const
         {
             size_type char_pos;
             return child(v, c, char_pos);
         }
 
-//! Get the i-th child of a node v.
+        //! Get the i-th child of a node v.
         /*!
          * \param v A valid tree node of the cst.
          * \param i 1-based Index of the child which should be returned. \f$i \geq 1\f$.

--- a/include/sdsl/cst_sct3.hpp
+++ b/include/sdsl/cst_sct3.hpp
@@ -811,7 +811,7 @@ class cst_sct3
 
         //! Get the child w of node v which edge label (v,w) starts with character c.
         // \sa child(node_type v, const char_type c, size_type &char_pos)
-        node_type child(const node_type& v, const char_type c)
+        node_type child(const node_type& v, const char_type c) const
         {
             size_type char_pos;
             return child(v, c, char_pos);


### PR DESCRIPTION
at child operator of CSTs.
Thanks @fermeise for pointing this out.