### PR TITLE
int vector mapper #2

### DIFF
--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -343,6 +343,7 @@ class int_vector_mapper
         }
 };
 
+
 template <uint8_t t_width = 0>
 class temp_file_buffer
 {

--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -368,7 +368,7 @@ template<std::ios_base::openmode t_mode = std::ios_base::out|std::ios_base::in>
 using bit_vector_mapper = int_vector_mapper<1,t_mode>;
 
 template<uint8_t t_width = 0>
-using read_only_mapper = int_vector_mapper<t_width,std::ios_base::in>;
+using read_only_mapper = const int_vector_mapper<t_width,std::ios_base::in>;
 
 } // end of namespace
 

--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -88,6 +88,7 @@ class int_vector_mapper
                     }
                 }
 
+                /* unmap data */
                 munmap(m_mapped_data, m_file_size_bytes);
 
                 if (t_mode&std::ios_base::out) {

--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -343,7 +343,7 @@ class int_vector_mapper
         }
 };
 
-
+/* temporary buffer that gets deleted later */
 template <uint8_t t_width = 0>
 class temp_file_buffer
 {

--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -393,7 +393,7 @@ class write_out_buffer
         }
         static int_vector_mapper<t_width> create(const std::string& file_name)
         {
-            //write empty int_vector to init the file
+            // write empty int_vector to init the file
             int_vector<t_width> tmp_vector;
             store_to_file(tmp_vector,file_name);
             return int_vector_mapper<t_width,std::ios_base::out|std::ios_base::in>(file_name,false,false);

--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -62,6 +62,7 @@ class int_vector_mapper
             }
         }
     public:
+        /* maps a resource. thus should not be copied or default constructed */
         int_vector_mapper() = delete;
         int_vector_mapper(const int_vector_mapper&) = delete;
         int_vector_mapper& operator=(const int_vector_mapper&) = delete;

--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -343,6 +343,10 @@ class temp_file_buffer
 template<std::ios_base::openmode t_mode = std::ios_base::out|std::ios_base::in>
 using bit_vector_mapper = int_vector_mapper<1,t_mode>;
 
+template<uint8_t t_width = 0>
+using read_only_mapper = int_vector_mapper<t_width,std::ios_base::in>;
+
+
 } // end of namespace
 
 #endif

--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -20,6 +20,10 @@ class int_vector_mapper
         typedef typename int_vector<t_width>::value_type value_type;
         typedef typename int_vector<t_width>::size_type size_type;
         typedef typename int_vector<t_width>::int_width_type width_type;
+        typedef typename int_vector<t_width>::const_iterator const_iterator;
+        typedef typename int_vector<t_width>::iterator iterator;
+        typedef typename int_vector<t_width>::const_reference const_reference;
+        typedef typename int_vector<t_width>::reference reference;
     public:
         const size_type append_block_size = 1000000;
     private:
@@ -219,39 +223,36 @@ class int_vector_mapper
             m_wrapper.m_size = bit_size;
         }
 
-
         void resize(const size_type size) {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'resize'");
             size_type size_in_bits = size * width();
             bit_resize(size_in_bits);
         }
 
-        auto begin() -> typename int_vector<t_width>::iterator {
+        iterator begin() {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'begin'");
             return m_wrapper.begin();
         }
-        auto end() -> typename int_vector<t_width>::iterator {
+        iterator end() {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'end'");
             return m_wrapper.end();
         }
-        auto begin() const -> typename int_vector<t_width>::const_iterator {
+        const_iterator begin() const {
             return m_wrapper.begin();
         }
-        auto end() const -> typename int_vector<t_width>::const_iterator {
+        const_iterator end() const {
             return m_wrapper.end();
         }
-        auto cbegin() const -> typename int_vector<t_width>::const_iterator {
+        const_iterator cbegin() const {
             return m_wrapper.begin();
         }
-        auto cend() const -> typename int_vector<t_width>::const_iterator {
+        const_iterator cend() const {
             return m_wrapper.end();
         }
-        auto operator[](const size_type& idx) const
-        -> typename int_vector<t_width>::const_reference {
+        const_reference operator[](const size_type& idx) const {
             return m_wrapper[idx];
         }
-        auto operator[](const size_type& idx)
-        -> typename int_vector<t_width>::reference {
+        reference operator[](const size_type& idx) {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'operator[]'");
             return m_wrapper[idx];
         }
@@ -306,6 +307,10 @@ class int_vector_mapper
         }
         bool empty() const {
             return m_wrapper.empty();
+        }
+        size_type max_size() const
+        {
+            return m_wrapper.max_size();
         }
 };
 

--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -340,12 +340,30 @@ class temp_file_buffer
         }
 };
 
+// creates emtpy int_vector<> that will not be deleted
+template <uint8_t t_width = 0>
+class write_out_buffer
+{
+    public:
+        static int_vector_mapper<t_width> create(const std::string& key,const cache_config& config) {
+            auto file_name = cache_file_name(key,config);
+            auto tmp = create(file_name);
+            register_cache_file(key,config);
+            return std::move(tmp);
+        }
+        static int_vector_mapper<t_width> create(const std::string& file_name) {
+            //write empty int_vector to init the file
+            int_vector<t_width> tmp_vector;
+            store_to_file(tmp_vector,file_name);
+            return int_vector_mapper<t_width,std::ios_base::out|std::ios_base::in>(file_name,false,false);
+        }
+};
+
 template<std::ios_base::openmode t_mode = std::ios_base::out|std::ios_base::in>
 using bit_vector_mapper = int_vector_mapper<1,t_mode>;
 
 template<uint8_t t_width = 0>
 using read_only_mapper = int_vector_mapper<t_width,std::ios_base::in>;
-
 
 } // end of namespace
 

--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -35,7 +35,8 @@ class int_vector_mapper
         std::string m_file_name;
         bool m_delete_on_close;
     private:
-        void mmap_file() {
+        void mmap_file()
+        {
             if (!(t_mode&std::ios_base::out)) {  // read only
                 m_mapped_data = (uint8_t*)mmap(NULL,
                                                m_file_size_bytes,
@@ -65,7 +66,8 @@ class int_vector_mapper
         int_vector_mapper(const int_vector_mapper&) = delete;
         int_vector_mapper& operator=(const int_vector_mapper&) = delete;
     public:
-        ~int_vector_mapper() {
+        ~int_vector_mapper()
+        {
             if (m_mapped_data) {
                 if (t_mode&std::ios_base::out) { // write was possible
                     if (m_data_offset) {
@@ -116,7 +118,8 @@ class int_vector_mapper
             m_wrapper.m_data = nullptr;
             m_wrapper.m_size = 0;
         }
-        int_vector_mapper(int_vector_mapper&& ivm) {
+        int_vector_mapper(int_vector_mapper&& ivm)
+        {
             m_wrapper.m_data = ivm.m_wrapper.m_data;
             m_wrapper.m_size = ivm.m_wrapper.m_size;
             m_wrapper.width(ivm.m_wrapper.width());
@@ -127,7 +130,8 @@ class int_vector_mapper
             ivm.m_mapped_data = nullptr;
             ivm.m_fd = -1;
         }
-        int_vector_mapper& operator=(int_vector_mapper&& ivm) {
+        int_vector_mapper& operator=(int_vector_mapper&& ivm)
+        {
             m_wrapper.m_data = ivm.m_wrapper.m_data;
             m_wrapper.m_size = ivm.m_wrapper.m_size;
             m_wrapper.width(ivm.m_wrapper.width());
@@ -144,7 +148,8 @@ class int_vector_mapper
         int_vector_mapper(const std::string filename,
                           bool is_plain = false,
                           bool delete_on_close = false) :
-            m_file_name(filename), m_delete_on_close(delete_on_close) {
+            m_file_name(filename), m_delete_on_close(delete_on_close)
+        {
             size_type size_in_bits = 0;
             uint8_t int_width = t_width;
             {
@@ -193,14 +198,17 @@ class int_vector_mapper
         }
         std::string file_name() const { return m_file_name; }
         width_type width() const { return m_wrapper.width(); }
-        void width(const uint8_t new_int_width) {
+        void width(const uint8_t new_int_width)
+        {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'width'");
             m_wrapper.width(new_int_width);
         }
-        size_type size() const {
+        size_type size() const
+        {
             return m_wrapper.size();
         }
-        void bit_resize(const size_type bit_size) {
+        void bit_resize(const size_type bit_size)
+        {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'bit_resize'");
             size_type new_size_in_bytes = ((bit_size + 63) >> 6) << 3;
             if (m_file_size_bytes != new_size_in_bytes + m_data_offset) {
@@ -223,52 +231,65 @@ class int_vector_mapper
             m_wrapper.m_size = bit_size;
         }
 
-        void resize(const size_type size) {
+        void resize(const size_type size)
+        {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'resize'");
             size_type size_in_bits = size * width();
             bit_resize(size_in_bits);
         }
 
-        iterator begin() {
+        iterator begin()
+        {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'begin'");
             return m_wrapper.begin();
         }
-        iterator end() {
+        iterator end()
+        {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'end'");
             return m_wrapper.end();
         }
-        const_iterator begin() const {
+        const_iterator begin() const
+        {
             return m_wrapper.begin();
         }
-        const_iterator end() const {
+        const_iterator end() const
+        {
             return m_wrapper.end();
         }
-        const_iterator cbegin() const {
+        const_iterator cbegin() const
+        {
             return m_wrapper.begin();
         }
-        const_iterator cend() const {
+        const_iterator cend() const
+        {
             return m_wrapper.end();
         }
-        const_reference operator[](const size_type& idx) const {
+        const_reference operator[](const size_type& idx) const
+        {
             return m_wrapper[idx];
         }
-        reference operator[](const size_type& idx) {
+        reference operator[](const size_type& idx)
+        {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'operator[]'");
             return m_wrapper[idx];
         }
         const uint64_t* data() const { return m_wrapper.data(); }
-        uint64_t* data() {
+        uint64_t* data()
+        {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'data'");
             return m_wrapper.data();
         }
-        value_type get_int(size_type idx, const uint8_t len = 64) const {
+        value_type get_int(size_type idx, const uint8_t len = 64) const
+        {
             return m_wrapper.get_int(idx, len);
         }
-        void set_int(size_type idx, value_type x, const uint8_t len = 64) {
+        void set_int(size_type idx, value_type x, const uint8_t len = 64)
+        {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'set_int'");
             m_wrapper.set_int(idx, x, len);
         }
-        void push_back(value_type x) {
+        void push_back(value_type x)
+        {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'push_back'");
             if (capacity() < size() + 1) {
                 size_type old_size = m_wrapper.m_size;
@@ -280,32 +301,40 @@ class int_vector_mapper
             m_wrapper.m_size += width();
             m_wrapper[size()-1] = x;
         }
-        size_type capacity() const {
+        size_type capacity() const
+        {
             size_t data_size_in_bits = 8 * (m_file_size_bytes - m_data_offset);
             return data_size_in_bits / width();
         }
-        size_type bit_size() const {
+        size_type bit_size() const
+        {
             return m_wrapper.bit_size();
         }
         template<class container>
-        bool operator==(const container& v) const {
+        bool operator==(const container& v) const
+        {
             return std::equal(begin(), end(), v.begin());
         }
-        bool operator==(const int_vector<t_width>& v) const {
+        bool operator==(const int_vector<t_width>& v) const
+        {
             return m_wrapper == v;
         }
-        bool operator==(const int_vector_mapper& v) const {
+        bool operator==(const int_vector_mapper& v) const
+        {
             return m_wrapper == v.m_wrapper;
         }
         template<class container>
-        bool operator!=(const container& v) const {
+        bool operator!=(const container& v) const
+        {
             return !(*this==v);
         }
-        void flip() {
+        void flip()
+        {
             static_assert(t_mode & std::ios_base::out,"int_vector_mapper: must be opened in in+out mode for 'flip'");
             m_wrapper.flip();
         }
-        bool empty() const {
+        bool empty() const
+        {
             return m_wrapper.empty();
         }
         size_type max_size() const
@@ -318,7 +347,8 @@ template <uint8_t t_width = 0>
 class temp_file_buffer
 {
     private:
-        static std::string tmp_file(const std::string& dir) {
+        static std::string tmp_file(const std::string& dir)
+        {
             char tmp_file_name[1024] = {0};
             sprintf(tmp_file_name, "%s/tmp_mapper_file_XXXXXX.sdsl",dir.c_str());
             int fd = mkstemps(tmp_file_name,5);
@@ -329,15 +359,18 @@ class temp_file_buffer
             return std::string(tmp_file_name,strlen(tmp_file_name));
         }
     public:
-        static int_vector_mapper<t_width> create() {
+        static int_vector_mapper<t_width> create()
+        {
             auto file_name = tmp_file("/tmp");
             return create(file_name);
         }
-        static int_vector_mapper<t_width> create(const cache_config& config) {
+        static int_vector_mapper<t_width> create(const cache_config& config)
+        {
             auto file_name = tmp_file(config.dir);
             return create(file_name);
         }
-        static int_vector_mapper<t_width> create(const std::string& file_name) {
+        static int_vector_mapper<t_width> create(const std::string& file_name)
+        {
             //write empty int_vector to init the file
             int_vector<t_width> tmp_vector;
             store_to_file(tmp_vector,file_name);
@@ -350,13 +383,15 @@ template <uint8_t t_width = 0>
 class write_out_buffer
 {
     public:
-        static int_vector_mapper<t_width> create(const std::string& key,const cache_config& config) {
+        static int_vector_mapper<t_width> create(const std::string& key,cache_config& config)
+        {
             auto file_name = cache_file_name(key,config);
             auto tmp = create(file_name);
             register_cache_file(key,config);
             return std::move(tmp);
         }
-        static int_vector_mapper<t_width> create(const std::string& file_name) {
+        static int_vector_mapper<t_width> create(const std::string& file_name)
+        {
             //write empty int_vector to init the file
             int_vector<t_width> tmp_vector;
             store_to_file(tmp_vector,file_name);


### PR DESCRIPTION
This pull request adds functionality to the int-vector-mapper (#232) such as  [x] typedef for a `read_only_mapper` [x] support class which allows the creation of output buffer: `write_out_buffer` [x] support class which supports the creation of temporary files which are deleted by the int-vector-mapper destructor `temp_file_buffer` [x] tests for the new functionality  the only remaining open functionality of the `int-vector-buffer` which is not yet implemented is the ability to handle `ram_files`. However, I suggest the following:  - Remove the majority of the ram file functionality. - When construct_im is called, set a flag somewhere which then forces the int-vector-mapper to not unmap the file in the destructor. Thus, if enough memory is available it remains in memory. - When the construct_im method is done, there is some call to "clean up" which would unmap everything and delete the leftover files (or nothing will be written to disk in the first place)