### PR TITLE
Fixed undefined behavior: left shift of negative signed integer.

### DIFF
--- a/include/sdsl/bits.hpp
+++ b/include/sdsl/bits.hpp
@@ -50,7 +50,7 @@ namespace sdsl
 struct bits {
     bits() = delete;
     //! 64bit mask with all bits set to 1.
-    constexpr static int64_t  all_set {-1LL};
+    constexpr static uint64_t  all_set {-1ULL};
 
     //! This constant represents a de Bruijn sequence B(k,n) for k=2 and n=6.
     /*! Details for de Bruijn sequences see


### PR DESCRIPTION
See:
- http://stackoverflow.com/questions/19593938/is-left-shifting-a-negative-integer-undefined-behavior-in-c11
- https://msdn.microsoft.com/en-us/library/336xbhcz.aspx (footnotes)