### PR TITLE
GLOB .cpp files in /lib/ only after cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,14 +63,14 @@ endif()
 
 #COMMENT REPLACED BY BIICODE
 
-add_subdirectory(external)
-add_subdirectory(include)
-add_subdirectory(lib)
-
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Make.helper.cmake"
 		       "${CMAKE_CURRENT_SOURCE_DIR}/Make.helper" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lib/structure_tree.cpp.cmake"
                "${CMAKE_CURRENT_SOURCE_DIR}/lib/structure_tree.cpp" @ONLY)
+
+add_subdirectory(external)
+add_subdirectory(include)
+add_subdirectory(lib)
 
 ## Add 'uninstall' target ##
 CONFIGURE_FILE(


### PR DESCRIPTION
the structure_tree.cpp was only generated after the /lib/ dir was
included in the cmake files and thus the structure_tree.cpp file was not
compiled (only works after a second call to ./install.sh). this adds to
/lib/ subdirectory only after the .cpp file is generated.

This fixes issue #260 