### PR TITLE
Allow store_to_file of std::string

### DIFF
--- a/include/sdsl/io.hpp
+++ b/include/sdsl/io.hpp
@@ -690,6 +690,8 @@ bool store_to_checked_file(const T& t, const std::string& file)
 
 bool store_to_file(const char* v, const std::string& file);
 
+bool store_to_file(const std::string& v, const std::string& file);
+
 template<uint8_t t_width>
 bool store_to_file(const int_vector<t_width>& v, const std::string& file, bool write_fixed_as_variable)
 {

--- a/lib/io.cpp
+++ b/lib/io.cpp
@@ -22,6 +22,21 @@ bool store_to_file(const char* v, const std::string& file)
     return true;
 }
 
+bool store_to_file(const std::string& v, const std::string& file)
+{
+    osfstream out(file, std::ios::binary | std::ios::trunc | std::ios::out);
+    if (!out) {
+        if (util::verbose) {
+            std::cerr<<"ERROR: store_to_file(const std::string& v, const std::string&)"<<std::endl;
+            return false;
+        }
+    }
+    out.write(v.data(),v.size());
+    out.close();
+    return true;
+}
+
+
 bool store_to_checked_file(const char* v, const std::string& file)
 {
     std::string checkfile = file+"_check";


### PR DESCRIPTION
This commit allows storage of std::string to file so construct_im
can be used to construct sdsl structures from std::string inputs.