### PR TITLE
Avoid ranks in backward search...

### DIFF
--- a/include/sdsl/csa_alphabet_strategy.hpp
+++ b/include/sdsl/csa_alphabet_strategy.hpp
@@ -27,13 +27,13 @@
 //       This can be also used for a integer based CSA.
 
 /* A alphabet strategy provides the following features:
- *   * Member `sigma` which contains the size (=umber of unique symbols) of the alphabet.
- *   * Method `is_present(char_type c)` which indicates if character c occurs in the text.
+ *   * Member `sigma` which contains the size (=number of unique symbols) of the alphabet.
  *   * Container `char2comp` which maps a symbol to a number [0..sigma-1]. The alphabetic
  *     order is preserved.
  *   * Container `comp2char` which is the inverse mapping of char2comp.
  *   * Container `C` contains the cumulative counts of occurrences. C[i] is the cumulative
  *     count of occurrences of symbols `comp2char[0]` to `comp2char[i-1]` in the text.
+ *     C is of size `sigma+1`.
  *   * Typedefs for the four above members:
  *       * char2comp_type
  *       * comp2char_type
@@ -220,7 +220,7 @@ class succinct_byte_alphabet
                 char2comp_wrapper(const succinct_byte_alphabet* strat) : m_strat(strat) {}
                 comp_char_type operator[](char_type c) const
                 {
-                   if ( c >= m_strat->m_char.size() or !m_strat->m_char[c] )
+                    if (c >= m_strat->m_char.size() or !m_strat->m_char[c])
                         return (comp_char_type)0;
                     return (comp_char_type) m_strat->m_char_rank((size_type)c);
                 }
@@ -420,11 +420,11 @@ class int_alphabet
                 comp_char_type operator[](char_type c) const
                 {
                     if (m_strat->m_char.size() > 0) {  // if alphabet is not continuous
-                        if ( c >= m_strat->m_char.size() or !m_strat->m_char[c] )
+                        if (c >= m_strat->m_char.size() or !m_strat->m_char[c])
                             return (comp_char_type)0;
                         return (comp_char_type) m_strat->m_char_rank((size_type)c);
                     } else { // direct map if it is continuous
-                        if ( c >= m_strat->m_sigma )
+                        if (c >= m_strat->m_sigma)
                             return 0;
                         return (comp_char_type) c;
                     }

--- a/include/sdsl/suffix_array_algorithm.hpp
+++ b/include/sdsl/suffix_array_algorithm.hpp
@@ -70,22 +70,20 @@ forward_search(
         return 0;
 
     // compares the pattern with CSA-prefix i (truncated to length $|pattern|$).
-    auto compare = [&] (typename t_csa::size_type i) -> int
+    auto compare = [&](typename t_csa::size_type i) -> int {
+        for (auto current = begin; current != end; current++)
         {
-            for (auto current = begin; current != end; current++)
-            {
-                auto index = csa.char2comp[*current];
-                if (index == 0) return -1;
-                if (csa.C[index + 1] - 1 < i) return -1;
-                if (csa.C[index] > i) return 1;
-                i = csa.psi[i];
-            }
-            return 0;
-        };
+            auto index = csa.char2comp[*current];
+            if (index == 0) return -1;
+            if (csa.C[index + 1] - 1 < i) return -1;
+            if (csa.C[index] > i) return 1;
+            i = csa.psi[i];
+        }
+        return 0;
+    };
 
     // binary search (on min)
-    while (l_res < l_res_upper)
-    {
+    while (l_res < l_res_upper) {
         typename t_csa::size_type sample = l_res + (l_res_upper - l_res) / 2;
         int result = compare(sample);
         if (result == 1)
@@ -97,8 +95,7 @@ forward_search(
     }
 
     // binary search (on max)
-    while (r_res + 1 < r_res_upper)
-    {
+    while (r_res + 1 < r_res_upper) {
         typename t_csa::size_type sample = r_res + (r_res_upper - r_res) / 2;
         int result = compare(sample);
         if (result == 1)
@@ -175,9 +172,20 @@ typename t_csa::size_type backward_search(
 )
 {
     assert(l <= r); assert(r < csa.size());
-    typename t_csa::size_type c_begin = csa.C[csa.char2comp[c]];
-    l_res = c_begin + csa.bwt.rank(l, c); // count c in bwt[0..l-1]
-    r_res = c_begin + csa.bwt.rank(r+1, c) - 1; // count c in bwt[0..r]
+    typename t_csa::size_type cc = csa.char2comp[c];
+    if (cc == 0 and c > 0) {
+        l_res = 1;
+        r_res = 0;
+    } else {
+        typename t_csa::size_type c_begin = csa.C[cc];
+        if (l == 0 and r+1 == csa.size()) {
+            l_res = c_begin;
+            r_res = csa.C[cc+1] - 1;
+        } else {
+            l_res = c_begin + csa.bwt.rank(l, c); // count c in bwt[0..l-1]
+            r_res = c_begin + csa.bwt.rank(r+1, c) - 1; // count c in bwt[0..r]
+        }
+    }
     assert(r_res+1-l_res >= 0);
     return r_res+1-l_res;
 }
@@ -483,12 +491,12 @@ typename t_csx::size_type count(
  *         occurrences of pattern in the CSA.
  */
 template<class t_csa, class t_pat_iter, class t_rac=int_vector<64>>
-        t_rac locate(
-            const t_csa&  csa,
-            t_pat_iter begin,
-            t_pat_iter end,
-            SDSL_UNUSED typename std::enable_if<std::is_same<csa_tag, typename t_csa::index_category>::value, csa_tag>::type x = csa_tag()
-        )
+t_rac locate(
+    const t_csa&  csa,
+    t_pat_iter begin,
+    t_pat_iter end,
+    SDSL_UNUSED typename std::enable_if<std::is_same<csa_tag, typename t_csa::index_category>::value, csa_tag>::type x = csa_tag()
+)
 {
     typename t_csa::size_type occ_begin, occ_end, occs;
     occs = backward_search(csa, 0, csa.size()-1, begin, end, occ_begin, occ_end);


### PR DESCRIPTION
...if the searched symbol does not occur in the index or
it is the first step of the search.