### PR TITLE
In-place construction of sd_vector

### DIFF
--- a/lib/sd_vector.cpp
+++ b/lib/sd_vector.cpp
@@ -1,0 +1,69 @@
+#include "sdsl/sd_vector.hpp"
+
+//! Namespace for the succinct data structure library
+namespace sdsl
+{
+
+sd_vector_builder::sd_vector_builder() :
+    m_size(0), m_capacity(0),
+    m_wl(0),
+    m_tail(0), m_items(0),
+    m_last_high(0), m_highpos(0)
+{
+}
+
+sd_vector_builder::sd_vector_builder(size_type n, size_type m) :
+    m_size(n), m_capacity(m),
+    m_wl(0),
+    m_tail(0), m_items(0),
+    m_last_high(0), m_highpos(0)
+{
+    if(m_capacity > m_size)
+    {
+        throw std::runtime_error("sd_vector_builder: requested capacity is larger than vector size.");
+    }
+    if(m_capacity == 0) { return; }
+
+    size_type logm = bits::hi(m_capacity) + 1, logn = bits::hi(m_size) + 1;
+    if(logm == logn)
+    {
+        logm--; // to ensure logn-logm > 0
+    }
+    m_wl = logn - logm;
+    m_low = int_vector<>(m_capacity, 0, m_wl);
+    m_high = bit_vector(m_capacity + (1ULL << logm), 0);
+}
+
+void
+sd_vector_builder::swap(sd_vector_builder& sdb)
+{
+    std::swap(m_size, sdb.m_size);
+    std::swap(m_capacity, sdb.m_capacity);
+    std::swap(m_wl, sdb.m_wl);
+    std::swap(m_tail, sdb.m_tail);
+    std::swap(m_items, sdb.m_items);
+    std::swap(m_last_high, sdb.m_last_high);
+    std::swap(m_highpos, sdb.m_highpos);
+    m_low.swap(sdb.m_low);
+    m_high.swap(sdb.m_high);
+}
+
+template<>
+sd_vector<>::sd_vector(sd_vector_builder& builder)
+{
+    if(builder.items() != builder.capacity())
+    {
+      throw std::runtime_error("sd_vector: the builder is not full.");
+    }
+
+    m_size = builder.m_size;
+    m_wl = builder.m_wl;
+    m_low.swap(builder.m_low);
+    m_high.swap(builder.m_high);
+    util::init_support(m_high_1_select, &m_high);
+    util::init_support(m_high_0_select, &m_high);
+
+    builder = sd_vector_builder();
+}
+
+} // end namespace

--- a/test/README.md
+++ b/test/README.md
@@ -1,18 +1,19 @@
 # Library test suite
 
 This directory contains test code for various data structures.
-We used the [googletest][GTEST] framework for testing. 
+We used the [googletest][GTEST] framework for testing.
 
-A call of `make test` in your cmake build directory will execute all tests. 
-If you only want to run a test of a specific component `X` then run 
+A call of `make test` in your cmake build directory will execute all tests.
+If you only want to run a test of a specific component `X` then run
 `make X`,  where X should be in the following list:
 
   * `bits-test` (tests basic bit operations)
   * `int-vector-test` (tests  [int_vector](../include/sdsl/int_vector.hpp))
   * `int-vector-buffer-test` (tests  [int_vector_buffer](../include/sdsl/int_vector_buffer.hpp))
-  * `bit-vector-test` (tests  [bit_vector](../include/sdsl/bit_vectors.hpp) strucutres)
+  * `bit-vector-test` (tests  [bit_vector](../include/sdsl/bit_vectors.hpp) structures)
+  * `sd-vector-test` (tests [sd_vector](../include/sdsl/sd_vector.hpp) constructors)
   * `rank-support-test` (tests  [rank_support](../include/sdsl/rank_support.hpp) structures)
-  * `select-support-test` and `select-support-0-test` 
+  * `select-support-test` and `select-support-0-test`
      (tests  [select_support](../include/sdsl/select_support.hpp) structures)
   * `wt-byte-test` (tests [wavelet trees](../include/sdsl/wavelet_trees.hpp) on byte alphabets)
   * `wt-int-test` (tests [wavelet trees](../include/sdsl/wavelet_trees.hpp) on integer alphabets)
@@ -25,9 +26,9 @@ If you only want to run a test of a specific component `X` then run
 Test inputs are downloaded as needed before the first execution of the test.
 See the [download.config](./download.config) files for details on the sources.
 
-Executing `make test` should take about 60 minutes on a recent machine. 
+Executing `make test` should take about 60 minutes on a recent machine.
 
-Please report, if a test fails. Thanks. 
+Please report, if a test fails. Thanks.
 
 ## Customization
 
@@ -36,10 +37,10 @@ Please report, if a test fails. Thanks.
 
 
 ## Acknowledgements
-  We thank 
+  We thank
   * Project Gutenberg for providing text files `faust.txt` and
     `zarathustra.txt`.
-  * Shane Culpepper for providing the test inputs 
+  * Shane Culpepper for providing the test inputs
     `keeper.int` and `moby.int` for the integer-alphabet CSAs and CSTs.
 
 

--- a/test/sd_vector_test.cpp
+++ b/test/sd_vector_test.cpp
@@ -1,0 +1,63 @@
+#include "sdsl/sd_vector.hpp"
+#include "gtest/gtest.h"
+
+using namespace sdsl;
+using namespace std;
+
+namespace
+{
+
+const size_t BV_SIZE = 1000000;
+
+TEST(sd_vector_test, iterator_constructor)
+{
+    std::vector<uint64_t> pos;
+    bit_vector bv(BV_SIZE);
+    std::mt19937_64 rng;
+    std::uniform_int_distribution<uint64_t> distribution(0, 9);
+    auto dice = bind(distribution, rng);
+    for (size_t i=0; i < bv.size(); ++i) {
+        if (0 == dice()) {
+            pos.emplace_back(i);
+            bv[i] = 1;
+        }
+    }
+    sd_vector<> sdv(pos.begin(),pos.end());
+    for (size_t i=0; i < bv.size(); ++i) {
+        ASSERT_EQ((bool)sdv[i],(bool)bv[i]);
+    }
+}
+
+TEST(sd_vector_test, builder_constructor)
+{
+    std::vector<uint64_t> pos;
+    bit_vector bv(BV_SIZE);
+    std::mt19937_64 rng;
+    std::uniform_int_distribution<uint64_t> distribution(0, 9);
+    auto dice = bind(distribution, rng);
+    size_t ones = 0;
+    for (size_t i=0; i < bv.size(); ++i) {
+        if (0 == dice()) {
+            pos.emplace_back(i);
+            bv[i] = 1;
+            ones++;
+        }
+    }
+    sd_vector_builder builder(BV_SIZE, ones);
+    for (auto i : pos) {
+        builder.set(i);
+    }
+    sd_vector<> sdv(builder);
+    for (size_t i=0; i < bv.size(); ++i) {
+        ASSERT_EQ((bool)sdv[i],(bool)bv[i]);
+    }
+}
+
+} // end namespace
+
+int main(int argc, char* argv[])
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
Build an `sd_vector` directly by setting the 1-bits in order. This is more space-efficient than construction from a pair of iterators, if you can list the positions of 1-bits without storing them explicitly. The following example is from `sd_vector_test.cpp`:

```
    sd_vector_builder builder(BV_SIZE, ones);
    for (auto i : pos) {
        builder.set(i);
    }
    sd_vector<> sdv(builder);
```

The `sd_vector` constructor takes the ownership of the contents of the builder, and clears the builder when finished.