### PR TITLE
fix int_vector implicit constructor small bug

### DIFF
--- a/include/sdsl/int_vector.hpp
+++ b/include/sdsl/int_vector.hpp
@@ -334,9 +334,14 @@ class int_vector
             \param int_width     The width of each integer.
             \sa resize, width
          */
-        int_vector(size_type size = 0, value_type default_value = 0,
+
+        int_vector(size_type size, value_type default_value,
                    uint8_t int_width = t_width);
 
+        //! Constructor to fix possible comparison with integeres issue.
+        explicit int_vector(size_type size = 0) : int_vector(size, static_cast<value_type>(0), t_width) {
+
+        }
         //! Constructor for initializer_list.
         template<class t_T>
         int_vector(std::initializer_list<t_T> il) : int_vector()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,12 +1,12 @@
 include_directories(#"${CMAKE_CURRENT_SOURCE_DIR}/../include"
-					"${CMAKE_CURRENT_BINARY_DIR}/../include" 
-					"${CMAKE_CURRENT_BINARY_DIR}/../external/libdivsufsort/include" 
-					)
+        "${CMAKE_CURRENT_BINARY_DIR}/../include"
+        "${CMAKE_CURRENT_BINARY_DIR}/../external/libdivsufsort/include"
+        )
 
 
 file(GLOB libFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}  "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp") # select all .cpp-files
 if(MSVC)
-file(GLOB headerFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}  "${CMAKE_CURRENT_SOURCE_DIR}/../include/sdsl/*.hpp") # select all .hpp-files
+    file(GLOB headerFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}  "${CMAKE_CURRENT_SOURCE_DIR}/../include/sdsl/*.hpp") # select all .hpp-files
 endif()
 
 set( sdsl_SRCS ${libFiles} ${headerFiles})
@@ -14,13 +14,13 @@ set( sdsl_SRCS ${libFiles} ${headerFiles})
 add_library( sdsl ${sdsl_SRCS} )
 
 install(TARGETS sdsl
-		RUNTIME DESTINATION bin
-		LIBRARY DESTINATION lib
-		ARCHIVE DESTINATION lib)	
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
 
 set_target_properties(sdsl PROPERTIES
-	VERSION "${LIBRARY_VERSION_FULL}"	
-	SOVERSION "${LIBRARY_VERSION_MAJOR}"	
-#	DEFINE_SYMBOL SDSL_BUILD_DLL
-#	RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/../examples"
-	)
+        VERSION "${LIBRARY_VERSION_FULL}"
+        SOVERSION "${LIBRARY_VERSION_MAJOR}"
+        #	DEFINE_SYMBOL SDSL_BUILD_DLL
+        #	RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/../examples"
+        )


### PR DESCRIPTION
int_vector was implicitly converting integers into int_vector objects, allowing the following code to be valid for the compiler:

 int_vector<> a = {1,2,3};
int_vector<>::size_type b = 2;
    if (a >= b) {
        cout << "this should not work!" << endl;
    }