### PR TITLE
Fix year in the reference

### DIFF
--- a/include/sdsl/wt_blcd.hpp
+++ b/include/sdsl/wt_blcd.hpp
@@ -45,7 +45,7 @@ struct balanced_shape;
  *  Roberto Grossi, Ankur Gupta, Jeffrey Scott Vitter:
  *  High-order entropy-compressed text indexes.
  *  Proceedings of the 14th Annual ACM-SIAM Symposium on
- *  Discrete Algorithms (SODA 2013).
+ *  Discrete Algorithms (SODA 2003).
  *
  * @ingroup wt
  */


### PR DESCRIPTION
The article is from 2003, not 2013.