### PR TITLE
mmapped temp file buffer filename pid type mismatch

### DIFF
--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -349,7 +349,7 @@ class temp_file_buffer
                 throw std::runtime_error("could not create temporary file.");
             }
 #else
-            sprintf(tmp_file_name, "%s/tmp_mapper_file_%d_XXXXXX.sdsl",dir.c_str(),util::pid());
+            sprintf(tmp_file_name, "%s/tmp_mapper_file_%lu_XXXXXX.sdsl",dir.c_str(),util::pid());
             int fd = mkstemps(tmp_file_name,5);
             if (fd == -1) {
                 throw std::runtime_error("could not create temporary file.");


### PR DESCRIPTION
small fix to make sure sprintf properly prints the return type of util::pid()