### PR TITLE
only attempt make uninstall-sdsl if makefile exists

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -23,7 +23,9 @@ if [ $? != 0 ]; then
 	exit 1
 fi
 
-make uninstall-sdsl
+if [ -f Makefile ]; then
+    make uninstall-sdsl
+fi
 
 if [ $? != 0 ]; then
     exit 1


### PR DESCRIPTION
This avoids a trivial (but confusing) error when attempting to `make clean` from a calling context.