### PR TITLE
WT nodes: Access to bitvector and associated sequence

### DIFF
--- a/examples/print_wt.cpp
+++ b/examples/print_wt.cpp
@@ -1,0 +1,60 @@
+#include <string>
+#include <queue>
+#include <array>
+#include <sdsl/wavelet_trees.hpp>
+
+using namespace sdsl;
+using namespace std;
+
+template<typename t_wt>
+void console_print_wt(const t_wt& wt)
+{
+    auto v = wt.root();
+    array<queue<decltype(v)>,2> q;
+    uint64_t level = 0;
+    q[level%2].push(v);
+    while (!q[level%2].empty()) {
+        while (!q[level%2].empty()) {
+            v = q[level%2].front();
+            q[level%2].pop();
+            if (!wt.empty(v)) {
+                if (!wt.is_leaf(v)) {
+                    for (auto it = wt.begin(v); it!=wt.end(v); ++it) {
+                        cout<<*it;
+                    }
+                    cout<<" ";
+                    auto vs = wt.expand(v);
+                    q[(level+1)%2].push(get<0>(vs));
+                    q[(level+1)%2].push(get<1>(vs));
+                } else {
+                    for (size_t i=0; i<wt.size(v); ++i) {
+                        cout<<wt.sym(v);
+                    }
+                    cout<<" ";
+                }
+            }
+        }
+        ++level;
+        cout << endl;
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    string s = "barbarabierbarbarbar";
+    if (argc > 1) {
+        s = argv[1];
+    }
+    cout << "T=" << s << endl;
+    wm_int<> wt;
+//    wt_blcd<bit_vector, bit_vector::rank_1_type, bit_vector::select_1_type, bit_vector::select_0_type, int_tree<>> wt;
+//    wt_hutu<> wt;
+//    wt_huff<> wt;
+//    wt_blcd<> wt;
+//    wt_int<> wt;
+    construct_im(wt, s, 1);
+    cout <<"--"<<endl;
+    cout << "T=" << wt << endl;
+
+    console_print_wt(wt);
+}

--- a/extras/cheatsheet/sdsl-cheatsheet.tex
+++ b/extras/cheatsheet/sdsl-cheatsheet.tex
@@ -405,10 +405,11 @@ $v$ a node, and $r$ a range.\\
 \\
 Traversable WTs provide also: 
 \code{root()}, \code{is\_leaf($v$)},
-\code{empty($v$)}, \code{sym($v$)},
+\code{empty($v$)}, \code{size($v$)}, \code{sym($v$)},
 \code{expand($v$)},
 \code{expand($v$,$r$)},
-\code{expand($v$,std::vector<$r$>)}.\\
+\code{expand($v$,std::vector<$r$>)},
+\code{begin($v$),end($v$)}.\\
 \code{lex\_ordered} WTs provide also:
 \code{lex\_count($i$,$j$,$c$)} and 
 \code{lex\_smaller\_count($i$,$c$)}.    

--- a/extras/cheatsheet/sdsl-cheatsheet.tex
+++ b/extras/cheatsheet/sdsl-cheatsheet.tex
@@ -409,7 +409,7 @@ Traversable WTs provide also:
 \code{expand($v$)},
 \code{expand($v$,$r$)},
 \code{expand($v$,std::vector<$r$>)},
-\code{begin($v$),end($v$)}.\\
+\code{bit\_vec($v$)}, \code{seq($v$)}.\\
 \code{lex\_ordered} WTs provide also:
 \code{lex\_count($i$,$j$,$c$)} and 
 \code{lex\_smaller\_count($i$,$c$)}.    

--- a/include/sdsl/bit_vector_il.hpp
+++ b/include/sdsl/bit_vector_il.hpp
@@ -64,6 +64,7 @@ class bit_vector_il
         typedef size_type                                   value_type;
         typedef bit_vector::difference_type                 difference_type;
         typedef random_access_const_iterator<bit_vector_il> iterator;
+        typedef iterator                                    const_iterator;
         typedef bv_tag                                      index_category;
 
         friend class rank_support_il<1,t_bs>;

--- a/include/sdsl/iterators.hpp
+++ b/include/sdsl/iterators.hpp
@@ -52,85 +52,101 @@ class random_access_const_iterator: public std::iterator<std::random_access_iter
         random_access_const_iterator(const t_rac* rac, size_type idx = 0) : m_rac(rac), m_idx(idx) { }
 
         //! Dereference operator for the Iterator.
-        const_reference operator*()const {
+        const_reference operator*()const
+        {
             return (*m_rac)[m_idx];
         }
 
         //! Prefix increment of the Iterator.
-        iterator& operator++() {
+        iterator& operator++()
+        {
             ++m_idx;
             return *this;
         }
 
         //! Postfix increment of the Iterator.
-        iterator operator++(int) {
+        iterator operator++(int)
+        {
             random_access_const_iterator it = *this;
             ++(*this);
             return it;
         }
 
         //! Prefix decrement of the Iterator.
-        iterator& operator--() {
+        iterator& operator--()
+        {
             --m_idx;
             return *this;
         }
 
         //! Postfix decrement of the Iterator.
-        iterator operator--(int) {
+        iterator operator--(int)
+        {
             random_access_const_iterator it = *this;
             --(*this);
             return it;
         }
 
-        iterator& operator+=(difference_type i) {
+        iterator& operator+=(difference_type i)
+        {
             if (i<0)
                 return *this -= (-i);
             m_idx += i;
             return *this;
         }
 
-        iterator& operator-=(difference_type i) {
+        iterator& operator-=(difference_type i)
+        {
             if (i<0)
                 return *this += (-i);
             m_idx -= i;
             return *this;
         }
 
-        iterator operator+(difference_type i) const {
+        iterator operator+(difference_type i) const
+        {
             iterator it = *this;
             return it += i;
         }
 
-        iterator operator-(difference_type i) const {
+        iterator operator-(difference_type i) const
+        {
             iterator it = *this;
             return it -= i;
         }
 
-        const_reference operator[](difference_type i) const {
+        const_reference operator[](difference_type i) const
+        {
             return *(*this + i);
         }
 
-        bool operator==(const iterator& it)const {
+        bool operator==(const iterator& it)const
+        {
             return it.m_rac == m_rac && it.m_idx == m_idx;
         }
 
-        bool operator!=(const iterator& it)const {
+        bool operator!=(const iterator& it)const
+        {
             return !(*this==it);
         }
 
-        bool operator<(const iterator& it)const {
+        bool operator<(const iterator& it)const
+        {
             return m_idx < it.m_idx;
         }
 
-        bool operator>(const iterator& it)const {
+        bool operator>(const iterator& it)const
+        {
             return m_idx > it.m_idx;
         }
 
-        bool operator>=(const iterator& it)const {
+        bool operator>=(const iterator& it)const
+        {
             return !(*this < it);
         }
 
-        bool operator<=(const iterator& it)const {
+        bool operator<=(const iterator& it)const
+        {
             return !(*this > it);
         }
 
@@ -148,6 +164,35 @@ inline random_access_const_iterator<t_rac> operator+(typename random_access_cons
 {
     return it+n;
 }
+
+
+template<typename t_F>
+struct random_access_container {
+    typedef int_vector<>::size_type                               size_type;
+    typedef int_vector<>::difference_type                         difference_type;
+    typedef typename std::result_of<t_F(size_type)>::type         value_type;
+    typedef random_access_const_iterator<random_access_container> iterator_type;
+
+    t_F f;
+    size_type m_size;
+
+    random_access_container() {};
+    random_access_container(t_F ff, size_type size) : f(ff), m_size(size) { }
+
+    value_type operator[](size_type i) const { return f(i); }
+
+    size_type size() const { return m_size; }
+
+    iterator_type begin() const
+    {
+        return iterator_type(this, 0);
+    }
+
+    iterator_type end() const
+    {
+        return iterator_type(this, size());
+    }
+};
 
 } // end namespace sdsl
 #endif

--- a/include/sdsl/rrr_vector.hpp
+++ b/include/sdsl/rrr_vector.hpp
@@ -80,6 +80,7 @@ class rrr_vector
         typedef bit_vector::difference_type              difference_type;
         typedef t_rac                                    rac_type;
         typedef random_access_const_iterator<rrr_vector> iterator;
+        typedef iterator                                 const_iterator;
         typedef bv_tag                                   index_category;
 
         typedef rank_support_rrr<1, t_bs, t_rac, t_k>   rank_1_type;

--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -55,8 +55,8 @@ class sd_vector;  // in sd_vector
  */
 class sd_vector_builder
 {
-    template<typename, typename, typename>
-    friend class sd_vector;
+        template<typename, typename, typename>
+        friend class sd_vector;
 
     public:
         typedef bit_vector::size_type size_type;
@@ -135,6 +135,7 @@ class sd_vector
         typedef size_type                               value_type;
         typedef bit_vector::difference_type             difference_type;
         typedef random_access_const_iterator<sd_vector> iterator;
+        typedef iterator                                const_iterator;
         typedef bv_tag                                  index_category;
         typedef t_select_0                              select_0_support_type;
         typedef t_select_1                              select_1_support_type;
@@ -266,9 +267,8 @@ class sd_vector
 
         sd_vector(sd_vector_builder& builder)
         {
-            if(builder.items() != builder.capacity())
-            {
-              throw std::runtime_error("sd_vector: builder is not at full capacity.");
+            if (builder.items() != builder.capacity()) {
+                throw std::runtime_error("sd_vector: builder is not at full capacity.");
             }
 
             m_size = builder.m_size;

--- a/include/sdsl/suffix_array_algorithm.hpp
+++ b/include/sdsl/suffix_array_algorithm.hpp
@@ -475,6 +475,30 @@ typename t_csx::size_type count(
     return count(csx, pat.begin(), pat.end(), tag);
 }
 
+//! Returns the lexicographic interval of a pattern in the SA
+/*!
+ * \tparam t_csx      Type of CSA/CST.
+ * \tparam t_pat_iter Type of pattern iterator.
+ *
+ * \param csx         CSA or CST object.
+ * \param begin       Iterator to the begin of the pattern.
+ * \param end         Iterator to the end (exlusive) of the pattern.
+ *
+ * \return The interval in the SA in which all suffixes are prefixed
+ *         by the given pattern.
+ */
+template<typename t_csx, typename t_pat_iter>
+auto lex_interval(
+    const t_csx& csx,
+    t_pat_iter begin,
+    t_pat_iter end
+) -> std::array<typename t_csx::size_type, 2> {
+    std::array<typename t_csx::size_type, 2> res;
+    backward_search(csx, 0, csx.size()-1, begin, end, res[0], res[1]);
+    return res;
+}
+
+
 //! Calculates all occurrences of a pattern pat in a CSA.
 /*!
  * \tparam t_csa      CSA type.

--- a/include/sdsl/wm_int.hpp
+++ b/include/sdsl/wm_int.hpp
@@ -465,7 +465,7 @@ class wm_int
             if (lb <= rb) {
                 std::vector<size_type> is(m_max_level+1);
                 std::vector<size_type> rank_off(m_max_level+1);
-                _range_search_2d(root(), range_type(lb, rb), vlb, vrb, 0, is,
+                _range_search_2d(root(), {lb, rb}, vlb, vrb, 0, is,
                                  rank_off, point_vec, report, cnt_answers);
             }
             return make_pair(cnt_answers, point_vec);
@@ -611,19 +611,6 @@ class wm_int
             }
         };
 
-        //! Iterator to the begin of the bitvector of inner node v
-        auto begin(const node_type& v) const -> decltype(m_tree.begin() + v.offset)
-        {
-            return m_tree.begin() + v.offset;
-        }
-
-        //! Iterator to the begin of the bitvector of inner node v
-        auto end(const node_type& v) const -> decltype(m_tree.begin() + v.offset + v.size)
-        {
-            return m_tree.begin() + v.offset + v.size;
-        }
-
-
 
         //! Checks if the node is a leaf node
         bool is_leaf(const node_type& v) const
@@ -631,16 +618,40 @@ class wm_int
             return v.level == m_max_level;
         }
 
+        //! Symbol of leaf node v
         value_type sym(const node_type& v) const
         {
             return v.sym;
         }
 
+        //! Random access container to bitvector of node v
+        auto bit_vec(const node_type& v) const -> node_bv_container<t_bitvector> {
+            return node_bv_container<t_bitvector>(begin(v), end(v));
+        }
+
+        //! Random access container to sequence of node v
+        auto seq(const node_type& v) const -> random_access_container<std::function<value_type(size_type)>> {
+            return random_access_container<std::function<value_type(size_type)>>([&v, this](size_type i)
+            {
+                node_type vv = v;
+                while (!is_leaf(vv)) {
+                    auto vs = expand(vv);
+                    auto rs = expand(vv, {0, i});
+                    bool bit = *(begin(vv)+i);
+                    i = std::get<1>(rs[bit]);
+                    vv = vs[bit];
+                }
+                return sym(vv);
+            }, size(v));
+        }
+
+        //! Indicates if node v is empty
         bool empty(const node_type& v) const
         {
             return v.size == (size_type)0;
         }
 
+        //! Return the size of node v
         auto size(const node_type& v) const -> decltype(v.size)
         {
             return v.size;
@@ -657,7 +668,7 @@ class wm_int
          *  \return Return a pair of nodes (left child, right child).
          *  \pre !is_leaf(v)
          */
-        std::pair<node_type, node_type>
+        std::array<node_type, 2>
         expand(const node_type& v) const
         {
             node_type v_right = v;
@@ -669,7 +680,7 @@ class wm_int
          *  \return Return a pair of nodes (left child, right child).
          *  \pre !is_leaf(v)
          */
-        std::pair<node_type, node_type>
+        std::array<node_type, 2>
         expand(node_type&& v) const
         {
             node_type v_left;
@@ -687,7 +698,7 @@ class wm_int
             v.level  = v.level + 1;
             v.sym    = (v.sym<<1)|1;
 
-            return std::make_pair(std::move(v_left), v);
+            return {std::move(v_left), v};
         }
 
         //! Returns for each range its left and right child ranges
@@ -700,7 +711,7 @@ class wm_int
          *          range mapped to the right child of v.
          *  \pre !is_leaf(v) and s>=v_s and e<=v_e
          */
-        std::pair<range_vec_type, range_vec_type>
+        std::array<range_vec_type, 2>
         expand(const node_type& v,
                const range_vec_type& ranges) const
         {
@@ -718,7 +729,7 @@ class wm_int
          *          range mapped to the right child of v.
          *  \pre !is_leaf(v) and s>=v_s and e<=v_e
          */
-        std::pair<range_vec_type, range_vec_type>
+        std::array<range_vec_type, 2>
         expand(const node_type& v,
                range_vec_type&& ranges) const
         {
@@ -726,18 +737,18 @@ class wm_int
             range_vec_type res(ranges.size());
             size_t i = 0;
             for (auto& r : ranges) {
-                auto sp_rank    = m_tree_rank(v.offset + r.first);
-                auto right_size = m_tree_rank(v.offset + r.second + 1)
+                auto sp_rank    = m_tree_rank(v.offset + r[0]);
+                auto right_size = m_tree_rank(v.offset + r[1] + 1)
                                   - sp_rank;
-                auto left_size  = (r.second-r.first+1)-right_size;
+                auto left_size  = (r[1]-r[0]+1)-right_size;
 
                 auto right_sp = sp_rank - v_sp_rank;
-                auto left_sp  = r.first - right_sp;
+                auto left_sp  = r[0] - right_sp;
 
-                r = range_type(left_sp, left_sp + left_size - 1);
-                res[i++] = range_type(right_sp, right_sp + right_size - 1);
+                r = {left_sp, left_sp + left_size - 1};
+                res[i++] = {right_sp, right_sp + right_size - 1};
             }
-            return make_pair(ranges, std::move(res));
+            return {ranges, std::move(res)};
         }
 
         //! Returns for a range its left and right child ranges
@@ -750,26 +761,42 @@ class wm_int
          *          range mapped to the right child of v.
          *  \pre !is_leaf(v) and s>=v_s and e<=v_e
          */
-        std::pair<range_type, range_type>
+        std::array<range_type, 2>
         expand(const node_type& v, const range_type& r) const
         {
             auto v_sp_rank = m_tree_rank(v.offset);  // this is already calculated in expand(v)
-            auto sp_rank    = m_tree_rank(v.offset + r.first);
-            auto right_size = m_tree_rank(v.offset + r.second + 1)
+            auto sp_rank    = m_tree_rank(v.offset + r[0]);
+            auto right_size = m_tree_rank(v.offset + r[1] + 1)
                               - sp_rank;
-            auto left_size  = (r.second-r.first+1)-right_size;
+            auto left_size  = (r[1]-r[0]+1)-right_size;
 
             auto right_sp = sp_rank - v_sp_rank;
-            auto left_sp  = r.first - right_sp;
+            auto left_sp  = r[0] - right_sp;
 
-            return make_pair(range_type(left_sp, left_sp + left_size - 1),
-                             range_type(right_sp, right_sp + right_size - 1));
+            return {{{left_sp, left_sp + left_size - 1},
+                    {right_sp, right_sp + right_size - 1}
+                }
+            };
         }
 
         //! return the path to the leaf for a given symbol
         std::pair<uint64_t,uint64_t> path(value_type c) const
         {
             return {m_max_level,c};
+        }
+
+    private:
+
+        //! Iterator to the begin of the bitvector of inner node v
+        auto begin(const node_type& v) const -> decltype(m_tree.begin() + v.offset)
+        {
+            return m_tree.begin() + v.offset;
+        }
+
+        //! Iterator to the begin of the bitvector of inner node v
+        auto end(const node_type& v) const -> decltype(m_tree.begin() + v.offset + v.size)
+        {
+            return m_tree.begin() + v.offset + v.size;
         }
 };
 

--- a/include/sdsl/wm_int.hpp
+++ b/include/sdsl/wm_int.hpp
@@ -611,6 +611,20 @@ class wm_int
             }
         };
 
+        //! Iterator to the begin of the bitvector of inner node v
+        auto begin(const node_type& v) const -> decltype(m_tree.begin() + v.offset)
+        {
+            return m_tree.begin() + v.offset;
+        }
+
+        //! Iterator to the begin of the bitvector of inner node v
+        auto end(const node_type& v) const -> decltype(m_tree.begin() + v.offset + v.size)
+        {
+            return m_tree.begin() + v.offset + v.size;
+        }
+
+
+
         //! Checks if the node is a leaf node
         bool is_leaf(const node_type& v) const
         {
@@ -625,6 +639,11 @@ class wm_int
         bool empty(const node_type& v) const
         {
             return v.size == (size_type)0;
+        }
+
+        auto size(const node_type& v) const -> decltype(v.size)
+        {
+            return v.size;
         }
 
         //! Return the root node

--- a/include/sdsl/wt_algorithm.hpp
+++ b/include/sdsl/wt_algorithm.hpp
@@ -37,7 +37,7 @@ intersect(const t_wt& wt, const std::vector<range_type>& ranges, typename t_wt::
     using pnvr_type      = std::pair<node_type, range_vec_type>;
     typedef std::stack<pnvr_type> stack_type;
 
-    static_assert(has_expand<t_wt, std::pair<node_type,node_type>(const node_type&)>::value,
+    static_assert(has_expand<t_wt, std::array<node_type,2>(const node_type&)>::value,
                   "intersect requires t_wt to have expand(const node_type&)");
 
     using p_t = std::pair<value_type,size_type>;
@@ -69,7 +69,7 @@ intersect(const t_wt& wt, const std::vector<range_type>& ranges, typename t_wt::
             if (t <= iv.size()) {
                 auto freq = std::accumulate(iv.begin(), iv.end(), 0ULL,
                 [](size_type acc, const range_type& r) {
-                    return acc+(r.second-r.first+1);
+                    return acc+(r[1]-r[0]+1);
                 });
                 res.emplace_back(wt.sym(x.first),freq);
             }
@@ -100,11 +100,11 @@ quantile_freq(const t_wt& wt, typename t_wt::size_type lb,
                   "quantile_freq requires a lex_ordered WT");
     using std::get;
     using node_type      = typename t_wt::node_type;
-    static_assert(has_expand<t_wt, std::pair<node_type,node_type>(const node_type&)>::value,
+    static_assert(has_expand<t_wt, std::array<node_type,2>(const node_type&)>::value,
                   "quantile_freq requires t_wt to have expand(const node_type&)");
 
     node_type v = wt.root();
-    range_type r(lb,rb);
+    range_type r {{lb,rb}};
 
     while (!wt.is_leaf(v)) {
         auto child        = wt.expand(v);
@@ -135,8 +135,8 @@ _interval_symbols_rec(const t_wt& wt, range_type r,
 {
     using std::get;
     if (wt.is_leaf(v)) {
-        rank_c_i[k] = r.first;
-        rank_c_j[k] = r.second+1;
+        rank_c_i[k] = r[0];
+        rank_c_j[k] = r[1]+1;
         cs[k++] = wt.sym(v);
     } else {
         auto child        = wt.expand(v);
@@ -172,7 +172,7 @@ _interval_symbols(const t_wt& wt, typename t_wt::size_type i,
         k=1;
         return;
     } else if (j>i) {
-        _interval_symbols_rec(wt, range_type(i,j-1), k, cs,
+        _interval_symbols_rec(wt, {i,j-1}, k, cs,
                               rank_c_i, rank_c_j, wt.root());
     }
 }

--- a/include/sdsl/wt_helper.hpp
+++ b/include/sdsl/wt_helper.hpp
@@ -80,12 +80,14 @@ struct _node {
 
     _node(uint64_t bv_pos=0, uint64_t bv_pos_rank=0, node_type parent=t_tree_strat_fat::undef,
           node_type child_left=t_tree_strat_fat::undef, node_type child_right=t_tree_strat_fat::undef):
-        bv_pos(bv_pos), bv_pos_rank(bv_pos_rank), parent(parent) {
+        bv_pos(bv_pos), bv_pos_rank(bv_pos_rank), parent(parent)
+    {
         child[0] = child_left;
         child[1] = child_right;
     }
 
-    _node& operator=(const _node& v) {
+    _node& operator=(const _node& v)
+    {
         if (this != &v) {
             bv_pos      = v.bv_pos;
             bv_pos_rank = v.bv_pos_rank;
@@ -96,7 +98,8 @@ struct _node {
         return *this;
     }
 
-    _node& operator=(const pc_node& v) {
+    _node& operator=(const pc_node& v)
+    {
         bv_pos      = v.freq;
         bv_pos_rank = v.sym;
         parent        = v.parent;
@@ -105,7 +108,8 @@ struct _node {
         return *this;
     }
 
-    size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const {
+    size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const
+    {
         structure_tree_node* st_child = structure_tree::add_child(v, name, util::class_name(*this));
         uint64_t written_bytes = 0;
         written_bytes += write_member(bv_pos, out);
@@ -117,7 +121,8 @@ struct _node {
         return written_bytes;
     }
 
-    void load(std::istream& in) {
+    void load(std::istream& in)
+    {
         read_member(bv_pos, in);
         read_member(bv_pos_rank, in);
         read_member(parent, in);
@@ -150,7 +155,8 @@ struct _byte_tree {
     // 0..55 hold path information; bits 56..63 the length
     // of the path in binary representation
 
-    void copy(const _byte_tree& bt) {
+    void copy(const _byte_tree& bt)
+    {
         m_nodes = bt.m_nodes;
         for (uint32_t i=0; i<fixed_sigma; ++i)
             m_c_to_leaf[i] = bt.m_c_to_leaf[i];
@@ -160,7 +166,8 @@ struct _byte_tree {
 
     _byte_tree() {}
 
-    _byte_tree(const std::vector<pc_node>& temp_nodes, uint64_t& bv_size, const t_wt*) {
+    _byte_tree(const std::vector<pc_node>& temp_nodes, uint64_t& bv_size, const t_wt*)
+    {
         m_nodes.resize(temp_nodes.size());
         m_nodes[0] = temp_nodes.back(); // insert root at index 0
         bv_size = 0;
@@ -233,18 +240,21 @@ struct _byte_tree {
     }
 
     template<class t_rank_type>
-    void init_node_ranks(const t_rank_type& rank) {
+    void init_node_ranks(const t_rank_type& rank)
+    {
         for (uint64_t i=0; i<m_nodes.size(); ++i) {
             if (m_nodes[i].child[0] != undef)  // if node is not a leaf
                 m_nodes[i].bv_pos_rank = rank.rank(m_nodes[i].bv_pos);
         }
     }
 
-    _byte_tree(const _byte_tree& bt) {
+    _byte_tree(const _byte_tree& bt)
+    {
         copy(bt);
     }
 
-    void swap(_byte_tree& bt) {
+    void swap(_byte_tree& bt)
+    {
         std::swap(m_nodes, bt.m_nodes);
         for (uint32_t i=0; i<fixed_sigma; ++i) {
             std::swap(m_c_to_leaf[i], bt.m_c_to_leaf[i]);
@@ -252,7 +262,8 @@ struct _byte_tree {
         }
     }
 
-    _byte_tree& operator=(const _byte_tree& bt) {
+    _byte_tree& operator=(const _byte_tree& bt)
+    {
         if (this != &bt) {
             copy(bt);
         }
@@ -261,7 +272,8 @@ struct _byte_tree {
 
     //! Serializes the data structure into the given ostream
     uint64_t serialize(std::ostream& out, structure_tree_node* v=nullptr,
-                       std::string name="") const {
+                       std::string name="") const
+    {
         structure_tree_node* child = structure_tree::add_child(
                                          v, name, util::class_name(*this));
         uint64_t written_bytes = 0;
@@ -277,7 +289,8 @@ struct _byte_tree {
     }
 
     //! Loads the data structure from the given istream.
-    void load(std::istream& in) {
+    void load(std::istream& in)
+    {
         uint64_t m_nodes_size = 0;
         read_member(m_nodes_size, in);
         m_nodes = std::vector<data_node>(m_nodes_size);
@@ -287,58 +300,75 @@ struct _byte_tree {
     }
 
     //! Get corresponding leaf for symbol c.
-    inline node_type c_to_leaf(value_type c)const {
+    inline node_type c_to_leaf(value_type c)const
+    {
         return m_c_to_leaf[c];
     }
     //! Return the root node of the tree.
-    inline static node_type root() {
+    inline static node_type root()
+    {
         return 0;
     }
 
     //! Return the number of nodes in the tree.
-    uint64_t size() const {
+    uint64_t size() const
+    {
         return m_nodes.size();
     }
 
     //! Return the parent node of v.
-    inline node_type parent(node_type v)const {
+    inline node_type parent(node_type v)const
+    {
         return m_nodes[v].parent;
     }
     //! Return left (i=0) or right (i=1) child node of v.
-    inline node_type child(node_type v, uint8_t i)const {
+    inline node_type child(node_type v, uint8_t i)const
+    {
         return m_nodes[v].child[i];
     }
 
     //! Return if v is a leaf node.
-    inline bool is_leaf(node_type v)const {
+    inline bool is_leaf(node_type v)const
+    {
         return m_nodes[v].child[0] == undef;
     }
 
+    //! Return size of an inner node
+    inline uint64_t size(node_type v) const
+    {
+        auto next_v = t_dfs_shape ? m_nodes[v].child[0] : v+1;
+        return bv_pos(next_v) - bv_pos(v);
+    }
+
     //! Return the path as left/right bit sequence in a uint64_t
-    inline uint64_t bit_path(value_type c)const {
+    inline uint64_t bit_path(value_type c)const
+    {
         return m_path[c];
     }
 
     //! Return the start of the node in the WT's bit vector
-    inline uint64_t bv_pos(node_type v)const {
+    inline uint64_t bv_pos(node_type v)const
+    {
         return m_nodes[v].bv_pos;
     }
 
     //! Returns for node v the rank of 1's up to bv_pos(v)
-    inline uint64_t bv_pos_rank(node_type v)const {
+    inline uint64_t bv_pos_rank(node_type v)const
+    {
         return m_nodes[v].bv_pos_rank;
     }
 
     //! Return if the node is a valid node
-    inline bool is_valid(node_type v)const {
+    inline bool is_valid(node_type v)const
+    {
         return v != undef;
     }
 
     //! Return symbol c or the next larger symbol in the wt
     inline std::pair<bool,value_type> symbol_gte(value_type c) const
     {
-        for(uint32_t i=c;i<fixed_sigma;i++) {
-            if(m_c_to_leaf[i]!=undef) {
+        for (uint32_t i=c; i<fixed_sigma; i++) {
+            if (m_c_to_leaf[i]!=undef) {
                 return {true,i};
             }
         }
@@ -348,12 +378,12 @@ struct _byte_tree {
     //! Return symbol c or the next smaller symbol in the wt
     inline std::pair<bool,value_type> symbol_lte(value_type c) const
     {
-        for(uint32_t i=c;i>0;i--) {
-            if(m_c_to_leaf[i]!=undef) {
+        for (uint32_t i=c; i>0; i--) {
+            if (m_c_to_leaf[i]!=undef) {
                 return {true,i};
             }
         }
-        if(m_c_to_leaf[0]!=undef)
+        if (m_c_to_leaf[0]!=undef)
             return {true,0};
         return {false,0};
     }
@@ -386,7 +416,8 @@ struct _int_tree {
     // 0..55 hold path information; bits 56..63 the length
     // of the path in binary representation
 
-    void copy(const _int_tree& bt) {
+    void copy(const _int_tree& bt)
+    {
         m_nodes     = bt.m_nodes;
         m_c_to_leaf = bt.m_c_to_leaf;
         m_path      = bt.m_path;
@@ -394,7 +425,8 @@ struct _int_tree {
 
     _int_tree() {}
 
-    _int_tree(const std::vector<pc_node>& temp_nodes, uint64_t& bv_size, const t_wt*) {
+    _int_tree(const std::vector<pc_node>& temp_nodes, uint64_t& bv_size, const t_wt*)
+    {
         m_nodes.resize(temp_nodes.size());
         m_nodes[0] = temp_nodes.back(); // insert root at index 0
         bv_size = 0;
@@ -475,24 +507,28 @@ struct _int_tree {
     }
 
     template<class t_rank_type>
-    void init_node_ranks(const t_rank_type& rank) {
+    void init_node_ranks(const t_rank_type& rank)
+    {
         for (uint64_t i=0; i<m_nodes.size(); ++i) {
             if (m_nodes[i].child[0] != undef)  // if node is not a leaf
                 m_nodes[i].bv_pos_rank = rank.rank(m_nodes[i].bv_pos);
         }
     }
 
-    _int_tree(const _int_tree& bt) {
+    _int_tree(const _int_tree& bt)
+    {
         copy(bt);
     }
 
-    void swap(_int_tree& bt) {
+    void swap(_int_tree& bt)
+    {
         std::swap(m_nodes, bt.m_nodes);
         std::swap(m_c_to_leaf, bt.m_c_to_leaf);
         std::swap(m_path, bt.m_path);
     }
 
-    _int_tree& operator=(const _int_tree& bt) {
+    _int_tree& operator=(const _int_tree& bt)
+    {
         if (this != &bt) {
             copy(bt);
         }
@@ -501,7 +537,8 @@ struct _int_tree {
 
     //! Serializes the data structure into the given ostream
     uint64_t serialize(std::ostream& out, structure_tree_node* v=nullptr,
-                       std::string name="") const {
+                       std::string name="") const
+    {
         structure_tree_node* child = structure_tree::add_child(
                                          v, name, util::class_name(*this));
         uint64_t written_bytes = 0;
@@ -519,7 +556,8 @@ struct _int_tree {
     }
 
     //! Loads the data structure from the given istream.
-    void load(std::istream& in) {
+    void load(std::istream& in)
+    {
         uint64_t m_nodes_size = 0;
         read_member(m_nodes_size, in);
         m_nodes = std::vector<data_node>(m_nodes_size);
@@ -535,38 +573,52 @@ struct _int_tree {
     }
 
     //! Get corresponding leaf for symbol c.
-    inline node_type c_to_leaf(value_type c)const {
+    inline node_type c_to_leaf(value_type c)const
+    {
         if (c >= m_c_to_leaf.size())
             return undef;
         else
             return m_c_to_leaf[c];
     }
     //! Return the root node of the tree.
-    inline static node_type root() {
+    inline static node_type root()
+    {
         return 0;
     }
 
     //! Return the number of nodes in the tree.
-    uint64_t size() const {
+    uint64_t size() const
+    {
         return m_nodes.size();
     }
 
     //! Return the parent node of v.
-    inline node_type parent(node_type v)const {
+    inline node_type parent(node_type v)const
+    {
         return m_nodes[v].parent;
     }
     //! Return left (i=0) or right (i=1) child node of v.
-    inline node_type child(node_type v, uint8_t i)const {
+    inline node_type child(node_type v, uint8_t i)const
+    {
         return m_nodes[v].child[i];
     }
 
     //! Return if v is a leaf node.
-    inline bool is_leaf(node_type v)const {
+    inline bool is_leaf(node_type v)const
+    {
         return m_nodes[v].child[0] == undef;
     }
 
+    //! Return size of an inner node
+    inline uint64_t size(node_type v) const
+    {
+        auto next_v = t_dfs_shape ? m_nodes[v].child[0] : v+1;
+        return bv_pos(next_v) - bv_pos(v);
+    }
+
     //! Return the path as left/right bit sequence in a uint64_t
-    inline uint64_t bit_path(value_type c)const {
+    inline uint64_t bit_path(value_type c)const
+    {
         if (c >= m_path.size()) {
             return m_path.size()-1;
         }
@@ -574,28 +626,31 @@ struct _int_tree {
     }
 
     //! Return the start of the node in the WT's bit vector
-    inline uint64_t bv_pos(node_type v)const {
+    inline uint64_t bv_pos(node_type v)const
+    {
         return m_nodes[v].bv_pos;
     }
 
     //! Returns for node v the rank of 1's up to bv_pos(v)
-    inline uint64_t bv_pos_rank(node_type v)const {
+    inline uint64_t bv_pos_rank(node_type v)const
+    {
         return m_nodes[v].bv_pos_rank;
     }
 
     //! Return if the node is a valid node
-    inline bool is_valid(node_type v)const {
+    inline bool is_valid(node_type v)const
+    {
         return v != undef;
     }
 
     //! Return symbol c or the next larger symbol in the wt
     inline std::pair<bool,value_type> symbol_gte(value_type c) const
     {
-        if(c >= m_c_to_leaf.size()) {
+        if (c >= m_c_to_leaf.size()) {
             return {false,0};
         }
-        for(value_type i=c;i<m_c_to_leaf.size();i++) {
-            if(m_c_to_leaf[i]!=undef) {
+        for (value_type i=c; i<m_c_to_leaf.size(); i++) {
+            if (m_c_to_leaf[i]!=undef) {
                 return {true,i};
             }
         }
@@ -605,16 +660,16 @@ struct _int_tree {
     //! Return symbol c or the next smaller symbol in the wt
     inline std::pair<bool,value_type> symbol_lte(value_type c) const
     {
-        if(c >= m_c_to_leaf.size()) {
+        if (c >= m_c_to_leaf.size()) {
             // return the largest symbol
             c = m_c_to_leaf.size()-1;
         }
-        for(value_type i=c;i>0;i--) {
-            if(m_c_to_leaf[i]!=undef) {
+        for (value_type i=c; i>0; i--) {
+            if (m_c_to_leaf[i]!=undef) {
                 return {true,i};
             }
         }
-        if(m_c_to_leaf[0]!=undef)
+        if (m_c_to_leaf[0]!=undef)
             return {true,0};
         return {false,0};
     }

--- a/include/sdsl/wt_helper.hpp
+++ b/include/sdsl/wt_helper.hpp
@@ -12,7 +12,7 @@
 namespace sdsl
 {
 
-typedef std::pair<int_vector<>::size_type, int_vector<>::size_type> range_type;
+typedef std::array<int_vector<>::size_type, 2> range_type;
 typedef std::vector<range_type>         range_vec_type;
 
 //! Empty range check
@@ -682,6 +682,55 @@ struct int_tree {
     template<class t_wt>
     using type = _int_tree<t_dfs_shape, t_wt>;
 };
+
+template<typename t_bv>
+class node_bv_container
+{
+    public:
+        typedef typename t_bv::value_type value_type;
+        typedef typename t_bv::size_type size_type;
+        typedef typename t_bv::difference_type difference_type;
+        typedef typename t_bv::const_iterator iterator;
+    private:
+        iterator m_begin, m_end;
+    public:
+        node_bv_container(iterator b, iterator e) : m_begin(b), m_end(e) {}
+        value_type operator[](size_type i) const { return *(m_begin+i); }
+        size_type size() const { return m_end - m_begin; }
+        iterator begin() const
+        {
+            return m_begin;
+        }
+        iterator end() const
+        {
+            return m_end;
+        }
+};
+
+template<typename t_bv>
+class node_seq_container
+{
+    public:
+        typedef typename t_bv::value_type value_type;
+        typedef typename t_bv::size_type size_type;
+        typedef typename t_bv::difference_type difference_type;
+        typedef typename t_bv::const_iterator iterator;
+    private:
+        iterator m_begin, m_end;
+    public:
+        node_seq_container(iterator b, iterator e) : m_begin(b), m_end(e) {}
+        value_type operator[](size_type i) const { return *(m_begin+i); }
+        size_type size() const { return m_end - m_begin; }
+        iterator begin() const
+        {
+            return m_begin;
+        }
+        iterator end() const
+        {
+            return m_end;
+        }
+};
+
 
 } // end namespace sdsl
 #endif

--- a/include/sdsl/wt_int.hpp
+++ b/include/sdsl/wt_int.hpp
@@ -798,34 +798,46 @@ class wt_int
             }
         };
 
-        //! Iterator to the begin of the bitvector of inner node v
-        auto begin(const node_type& v) const -> decltype(m_tree.begin() + v.offset)
-        {
-            return m_tree.begin() + v.offset;
-        }
-
-        //! Iterator to the begin of the bitvector of inner node v
-        auto end(const node_type& v) const -> decltype(m_tree.begin() + v.offset + v.size)
-        {
-            return m_tree.begin() + v.offset + v.size;
-        }
-
         //! Checks if the node is a leaf node
         bool is_leaf(const node_type& v) const
         {
             return v.level == m_max_level;
         }
 
+        //! Returns the symbol of leaf node v
         value_type sym(const node_type& v) const
         {
             return v.sym;
         }
 
+        //! Random access container to bitvector of node v
+        auto bit_vec(const node_type& v) const -> node_bv_container<t_bitvector> {
+            return node_bv_container<t_bitvector>(begin(v), end(v));
+        }
+
+        //! Random access container to sequence of node v
+        auto seq(const node_type& v) const -> random_access_container<std::function<value_type(size_type)>> {
+            return random_access_container<std::function<value_type(size_type)>>([&v, this](size_type i)
+            {
+                node_type vv = v;
+                while (!is_leaf(vv)) {
+                    auto vs = expand(vv);
+                    auto rs = expand(vv, {0, i});
+                    bool bit = *(begin(vv)+i);
+                    i = std::get<1>(rs[bit]);
+                    vv = vs[bit];
+                }
+                return sym(vv);
+            }, size(v));
+        }
+
+        //! Indicates if node v is empty
         bool empty(const node_type& v) const
         {
             return v.size == (size_type)0;
         }
 
+        //! Return the size of node v
         auto size(const node_type& v) const -> decltype(v.size)
         {
             return v.size;
@@ -839,10 +851,10 @@ class wt_int
 
         //! Returns the two child nodes of an inner node
         /*! \param v An inner node of a wavelet tree.
-         *  \return Return a pair of nodes (left child, right child).
+         *  \return Return an array of nodes (left child, right child).
          *  \pre !is_leaf(v)
          */
-        std::pair<node_type, node_type>
+        std::array<node_type, 2>
         expand(const node_type& v) const
         {
             node_type v_right = v;
@@ -851,10 +863,10 @@ class wt_int
 
         //! Returns the two child nodes of an inner node
         /*! \param v An inner node of a wavelet tree.
-         *  \return Return a pair of nodes (left child, right child).
+         *  \return Return an array of nodes (left child, right child).
          *  \pre !is_leaf(v)
          */
-        std::pair<node_type, node_type>
+        std::array<node_type, 2>
         expand(node_type&& v) const
         {
             node_type v_left;
@@ -871,7 +883,7 @@ class wt_int
             v.level  = v.level + 1;
             v.sym    = (v.sym<<1)|1;
 
-            return std::make_pair(std::move(v_left), v);
+            return {std::move(v_left), v};
         }
 
         //! Returns for each range its left and right child ranges
@@ -884,7 +896,7 @@ class wt_int
          *          range mapped to the right child of v.
          *  \pre !is_leaf(v) and s>=v_s and e<=v_e
          */
-        std::pair<range_vec_type, range_vec_type>
+        std::array<range_vec_type, 2>
         expand(const node_type& v,
                const range_vec_type& ranges) const
         {
@@ -902,7 +914,7 @@ class wt_int
          *          range mapped to the right child of v.
          *  \pre !is_leaf(v) and s>=v_s and e<=v_e
          */
-        std::pair<range_vec_type, range_vec_type>
+        std::array<range_vec_type, 2>
         expand(const node_type& v,
                range_vec_type&& ranges) const
         {
@@ -910,18 +922,18 @@ class wt_int
             range_vec_type res(ranges.size());
             size_t i = 0;
             for (auto& r : ranges) {
-                auto sp_rank    = m_tree_rank(v.offset + r.first);
-                auto right_size = m_tree_rank(v.offset + r.second + 1)
+                auto sp_rank    = m_tree_rank(v.offset + r[0]);
+                auto right_size = m_tree_rank(v.offset + r[1] + 1)
                                   - sp_rank;
-                auto left_size  = (r.second-r.first+1)-right_size;
+                auto left_size  = (r[1]-r[0]+1)-right_size;
 
                 auto right_sp = sp_rank - v_sp_rank;
-                auto left_sp  = r.first - right_sp;
+                auto left_sp  = r[0] - right_sp;
 
-                r = range_type(left_sp, left_sp + left_size - 1);
-                res[i++] = range_type(right_sp, right_sp + right_size - 1);
+                r = {left_sp, left_sp + left_size - 1};
+                res[i++] = {right_sp, right_sp + right_size - 1};
             }
-            return make_pair(ranges, std::move(res));
+            return {ranges, std::move(res)};
         }
 
         //! Returns for a range its left and right child ranges
@@ -934,26 +946,42 @@ class wt_int
          *          range mapped to the right child of v.
          *  \pre !is_leaf(v) and s>=v_s and e<=v_e
          */
-        std::pair<range_type, range_type>
+        std::array<range_type, 2>
         expand(const node_type& v, const range_type& r) const
         {
             auto v_sp_rank = m_tree_rank(v.offset);  // this is already calculated in expand(v)
-            auto sp_rank    = m_tree_rank(v.offset + r.first);
-            auto right_size = m_tree_rank(v.offset + r.second + 1)
+            auto sp_rank    = m_tree_rank(v.offset + r[0]);
+            auto right_size = m_tree_rank(v.offset + r[1] + 1)
                               - sp_rank;
-            auto left_size  = (r.second-r.first+1)-right_size;
+            auto left_size  = (r[1]-r[0]+1)-right_size;
 
             auto right_sp = sp_rank - v_sp_rank;
-            auto left_sp  = r.first - right_sp;
+            auto left_sp  = r[0] - right_sp;
 
-            return make_pair(range_type(left_sp, left_sp + left_size - 1),
-                             range_type(right_sp, right_sp + right_size - 1));
+            return {{{left_sp, left_sp + left_size - 1},
+                    {right_sp, right_sp + right_size - 1}
+                }
+            };
         }
 
         //! return the path to the leaf for a given symbol
         std::pair<uint64_t,uint64_t> path(value_type c) const
         {
             return {m_max_level,c};
+        }
+
+    private:
+
+        //! Iterator to the begin of the bitvector of inner node v
+        auto begin(const node_type& v) const -> decltype(m_tree.begin() + v.offset)
+        {
+            return m_tree.begin() + v.offset;
+        }
+
+        //! Iterator to the begin of the bitvector of inner node v
+        auto end(const node_type& v) const -> decltype(m_tree.begin() + v.offset + v.size)
+        {
+            return m_tree.begin() + v.offset + v.size;
         }
 };
 

--- a/include/sdsl/wt_int.hpp
+++ b/include/sdsl/wt_int.hpp
@@ -798,6 +798,18 @@ class wt_int
             }
         };
 
+        //! Iterator to the begin of the bitvector of inner node v
+        auto begin(const node_type& v) const -> decltype(m_tree.begin() + v.offset)
+        {
+            return m_tree.begin() + v.offset;
+        }
+
+        //! Iterator to the begin of the bitvector of inner node v
+        auto end(const node_type& v) const -> decltype(m_tree.begin() + v.offset + v.size)
+        {
+            return m_tree.begin() + v.offset + v.size;
+        }
+
         //! Checks if the node is a leaf node
         bool is_leaf(const node_type& v) const
         {
@@ -812,6 +824,11 @@ class wt_int
         bool empty(const node_type& v) const
         {
             return v.size == (size_type)0;
+        }
+
+        auto size(const node_type& v) const -> decltype(v.size)
+        {
+            return v.size;
         }
 
         //! Return the root node

--- a/include/sdsl/wt_pc.hpp
+++ b/include/sdsl/wt_pc.hpp
@@ -92,7 +92,8 @@ class wt_pc
         select_0_type    m_bv_select0;
         tree_strat_type  m_tree;
 
-        void copy(const wt_pc& wt) {
+        void copy(const wt_pc& wt)
+        {
             m_size            = wt.m_size;
             m_sigma           = wt.m_sigma;
             m_bv              = wt.m_bv;
@@ -107,7 +108,8 @@ class wt_pc
 
         // insert a character into the wavelet tree, see construct method
         void insert_char(value_type old_chr, std::vector<uint64_t>& bv_node_pos,
-                         size_type times, bit_vector& bv) {
+                         size_type times, bit_vector& bv)
+        {
             uint64_t p = m_tree.bit_path(old_chr);
             uint32_t path_len = p>>56;
             node_type v = m_tree.root();
@@ -123,7 +125,8 @@ class wt_pc
 
 
         // calculates the tree shape returns the size of the WT bit vector
-        size_type construct_tree_shape(const std::vector<size_type>& C) {
+        size_type construct_tree_shape(const std::vector<size_type>& C)
+        {
             // vector  for node of the tree
             std::vector<pc_node> temp_nodes; //(2*m_sigma-1);
             shape_type::construct_tree(C, temp_nodes);
@@ -135,7 +138,8 @@ class wt_pc
             return bv_size;
         }
 
-        void construct_init_rank_select() {
+        void construct_init_rank_select()
+        {
             util::init_support(m_bv_rank, &m_bv);
             util::init_support(m_bv_select0, &m_bv);
             util::init_support(m_bv_select1, &m_bv);
@@ -146,7 +150,8 @@ class wt_pc
         _interval_symbols(size_type i, size_type j, size_type& k,
                           std::vector<value_type>& cs,
                           std::vector<size_type>& rank_c_i,
-                          std::vector<size_type>& rank_c_j, node_type v) const {
+                          std::vector<size_type>& rank_c_j, node_type v) const
+        {
             // invariant: j>i
             size_type i_new = (m_bv_rank(m_tree.bv_pos(v) + i)
                                - m_tree.bv_pos_rank(v));
@@ -194,7 +199,8 @@ class wt_pc
          *      \f$ \Order{n\log|\Sigma|}\f$, where \f$n=size\f$
          */
         wt_pc(int_vector_buffer<tree_strat_type::int_width>& input_buf,
-              size_type size):m_size(size) {
+              size_type size):m_size(size)
+        {
             if (0 == m_size)
                 return;
             // O(n + |\Sigma|\log|\Sigma|) algorithm for calculating node sizes
@@ -250,12 +256,14 @@ class wt_pc
         //! Copy constructor
         wt_pc(const wt_pc& wt) { copy(wt); }
 
-        wt_pc(wt_pc&& wt) {
+        wt_pc(wt_pc&& wt)
+        {
             *this = std::move(wt);
         }
 
         //! Assignment operator
-        wt_pc& operator=(const wt_pc& wt) {
+        wt_pc& operator=(const wt_pc& wt)
+        {
             if (this != &wt) {
                 copy(wt);
             }
@@ -263,7 +271,8 @@ class wt_pc
         }
 
         //! Assignment operator
-        wt_pc& operator=(wt_pc&& wt) {
+        wt_pc& operator=(wt_pc&& wt)
+        {
             if (this != &wt) {
                 m_size            = wt.m_size;
                 m_sigma           = wt.m_sigma;
@@ -281,7 +290,8 @@ class wt_pc
 
 
         //! Swap operator
-        void swap(wt_pc& wt) {
+        void swap(wt_pc& wt)
+        {
             if (this != &wt) {
                 std::swap(m_size, wt.m_size);
                 std::swap(m_sigma,  wt.m_sigma);
@@ -314,7 +324,8 @@ class wt_pc
          * \par Precondition
          *      \f$ i < size() \f$
          */
-        value_type operator[](size_type i)const {
+        value_type operator[](size_type i)const
+        {
             assert(i < size());
             // which stores how many of the next symbols are equal
             // with the current char
@@ -346,7 +357,8 @@ class wt_pc
          * \par Precondition
          *      \f$ i \leq size() \f$
          */
-        size_type rank(size_type i, value_type c)const {
+        size_type rank(size_type i, value_type c)const
+        {
             assert(i <= size());
             if (!m_tree.is_valid(m_tree.c_to_leaf(c))) {
                 return 0;  // if `c` was not in the text
@@ -382,7 +394,8 @@ class wt_pc
          *      \f$ i < size() \f$
          */
         std::pair<size_type, value_type>
-        inverse_select(size_type i)const {
+        inverse_select(size_type i)const
+        {
             assert(i < size());
             node_type v = m_tree.root();
             while (!m_tree.is_leaf(v)) {   // while not a leaf
@@ -411,7 +424,8 @@ class wt_pc
          * \par Precondition
          *      \f$ 1 \leq i \leq rank(size(), c) \f$
          */
-        size_type select(size_type i, value_type c)const {
+        size_type select(size_type i, value_type c)const
+        {
             assert(1 <= i and i <= rank(size(), c));
             node_type v = m_tree.c_to_leaf(c);
             if (!m_tree.is_valid(v)) {   // if c was not in the text
@@ -466,7 +480,8 @@ class wt_pc
         void interval_symbols(size_type i, size_type j, size_type& k,
                               std::vector<value_type>& cs,
                               std::vector<size_type>& rank_c_i,
-                              std::vector<size_type>& rank_c_j) const {
+                              std::vector<size_type>& rank_c_j) const
+        {
             assert(i <= j and j <= size());
             if (i==j) {
                 k = 0;
@@ -522,7 +537,8 @@ class wt_pc
          */
         template<class t_ret_type = std::tuple<size_type, size_type, size_type>>
         typename std::enable_if<shape_type::lex_ordered, t_ret_type>::type
-        lex_count(size_type i, size_type j, value_type c) const {
+        lex_count(size_type i, size_type j, value_type c) const
+        {
             assert(i <= j and j <= size());
             if (1==m_sigma) {
                 value_type _c = m_tree.bv_pos_rank(m_tree.root());
@@ -583,7 +599,8 @@ class wt_pc
          */
         template<class t_ret_type = std::tuple<size_type, size_type>>
         typename std::enable_if<shape_type::lex_ordered, t_ret_type>::type
-        lex_smaller_count(size_type i, value_type c)const {
+        lex_smaller_count(size_type i, value_type c)const
+        {
             assert(i <= size());
             if (1==m_sigma) {
                 value_type _c = m_tree.bv_pos_rank(m_tree.root());
@@ -624,18 +641,21 @@ class wt_pc
         }
 
         //! Returns a const_iterator to the first element.
-        const_iterator begin()const {
+        const_iterator begin()const
+        {
             return const_iterator(this, 0);
         }
 
         //! Returns a const_iterator to the element after the last element.
-        const_iterator end()const {
+        const_iterator end()const
+        {
             return const_iterator(this, size());
         }
 
         //! Serializes the data structure into the given ostream
         size_type serialize(std::ostream& out, structure_tree_node* v=nullptr,
-                            std::string name="") const {
+                            std::string name="") const
+        {
             structure_tree_node* child = structure_tree::add_child(
                                              v, name, util::class_name(*this));
             size_type written_bytes = 0;
@@ -651,7 +671,8 @@ class wt_pc
         }
 
         //! Loads the data structure from the given istream.
-        void load(std::istream& in) {
+        void load(std::istream& in)
+        {
             read_member(m_size, in);
             read_member(m_sigma, in);
             m_bv.load(in);
@@ -661,22 +682,56 @@ class wt_pc
             m_tree.load(in);
         }
 
+        //! Iterator to the begin of the bitvector of inner node v
+        auto begin(const node_type& v) const -> decltype(m_bv.begin() + m_tree.bv_pos(v))
+        {
+            return m_bv.begin() + m_tree.bv_pos(v);
+        }
+
+        //! Iterator to the begin of the bitvector of inner node v
+        auto end(const node_type& v) const -> decltype(m_bv.begin() + m_tree.bv_pos(v) + m_tree.size(v))
+        {
+            return m_bv.begin() + m_tree.bv_pos(v) + m_tree.size(v);
+        }
+
         //! Checks if the node is a leaf node
-        bool is_leaf(const node_type& v) const {
+        bool is_leaf(const node_type& v) const
+        {
             return m_tree.is_leaf(v);
         }
 
         //! Symbol for a leaf
-        value_type sym(const node_type& v) const {
+        value_type sym(const node_type& v) const
+        {
             return m_tree.bv_pos_rank(v);
         }
 
-        bool empty(const node_type&) const {
-            return true;
+        bool empty(const node_type& v) const
+        {
+            return size(v)==0;
+        }
+
+        auto size(const node_type& v) const -> decltype(m_tree.size(v))
+        {
+            if (is_leaf(v)) {
+                if (v == root())
+                    return size();
+                else {
+                    auto parent = m_tree.parent(v);
+                    auto rs = expand(parent, {0, size(parent)-1});
+                    if (m_tree.child(parent, 0) == v)
+                        return std::get<1>(std::get<0>(rs))-std::get<0>((std::get<0>(rs)))+1;
+                    else
+                        return std::get<1>(std::get<1>(rs))-std::get<0>((std::get<1>(rs)))+1;
+                }
+            } else {
+                return m_tree.size(v);
+            }
         }
 
         //! Returns the root node
-        node_type root() const {
+        node_type root() const
+        {
             return m_tree.root();
         }
 
@@ -686,7 +741,8 @@ class wt_pc
          *  \pre !is_leaf(v)
          */
         std::pair<node_type, node_type>
-        expand(const node_type& v) const {
+        expand(const node_type& v) const
+        {
             return std::make_pair(m_tree.child(v,0), m_tree.child(v,1));
         }
 
@@ -702,7 +758,8 @@ class wt_pc
          */
         std::pair<range_vec_type, range_vec_type>
         expand(const node_type& v,
-               const range_vec_type& ranges) const {
+               const range_vec_type& ranges) const
+        {
             auto ranges_copy = ranges;
             return expand(v, std::move(ranges_copy));
         }
@@ -719,7 +776,8 @@ class wt_pc
          */
         std::pair<range_vec_type, range_vec_type>
         expand(const node_type& v,
-               range_vec_type&& ranges) const {
+               range_vec_type&& ranges) const
+        {
             auto v_sp_rank = m_tree.bv_pos_rank(v);
             range_vec_type res(ranges.size());
             size_t i = 0;
@@ -749,7 +807,8 @@ class wt_pc
          *  \pre !is_leaf(v) and s>=v_s and e<=v_e
          */
         std::pair<range_type, range_type>
-        expand(const node_type& v, const range_type& r) const {
+        expand(const node_type& v, const range_type& r) const
+        {
             auto v_sp_rank = m_tree.bv_pos_rank(v);
             auto sp_rank    = m_bv_rank(m_tree.bv_pos(v) + r.first);
             auto right_size = m_bv_rank(m_tree.bv_pos(v) + r.second + 1)
@@ -764,7 +823,8 @@ class wt_pc
         }
 
         //! return the path to the leaf for a given symbol
-        std::pair<uint64_t,uint64_t> path(value_type c) const {
+        std::pair<uint64_t,uint64_t> path(value_type c) const
+        {
             uint64_t path = m_tree.bit_path(c);
             uint64_t path_len = path >> 56;
             // reverse the path till we fix the ordering
@@ -779,7 +839,8 @@ class wt_pc
          *          a valid answer was found (true) or no valid answer (false)
          *          could be found. The second element contains the found symbol.
          */
-        std::pair<bool, value_type> symbol_gte(value_type c) const {
+        std::pair<bool, value_type> symbol_gte(value_type c) const
+        {
             return m_tree.symbol_gte(c);
         }
 
@@ -789,7 +850,8 @@ class wt_pc
          *          a valid answer was found (true) or no valid answer (false)
          *          could be found. The second element contains the found symbol.
          */
-        std::pair<bool, value_type> symbol_lte(value_type c) const {
+        std::pair<bool, value_type> symbol_lte(value_type c) const
+        {
             return m_tree.symbol_lte(c);
         }
 };

--- a/lib/wt_helper.cpp
+++ b/lib/wt_helper.cpp
@@ -5,12 +5,12 @@ namespace sdsl
 
 bool empty(const range_type& r)
 {
-    return r.first == r.second + 1;
+    return std::get<0>(r) == (std::get<1>(r) + 1);
 }
 
 int_vector<>::size_type size(const range_type& r)
 {
-    return r.second - r.first + 1;
+    return std::get<1>(r) - std::get<0>(r) + 1;
 }
 
 

--- a/test/wt_int_test.cpp
+++ b/test/wt_int_test.cpp
@@ -506,7 +506,7 @@ test_intersect(typename enable_if<has_node_type<t_wt>::value,t_wt>::type& wt)
             size_type lb = dice_lb();
             size_type rb = lb+dice_range()-1;
             rb = (rb >= wt.size()) ? wt.size()-1 : rb;
-            ranges.emplace_back(lb,rb);
+            ranges.push_back({lb,rb});
             buf_end[i] = copy(iv.begin()+lb,
                               iv.begin()+rb+1, buf[i].begin());
             sort(buf[i].begin(), buf_end[i]);


### PR DESCRIPTION
Access to the bitvector and symbol sequence of a WT node through methods
  * `bit_vec(v)`
  * `seq(v)`
In the case of `bit_vec(v)` v has to be an inner node, while `seq(v)` is defined for all nodes.
Both methods return a random access container and allow access to the bitvector and symbol sequence of the node `v`. Access time to one symbol is dependent on the depth of the WT. Access time to the bitvector is only a constant overhead.