### PR TITLE
Addressed issue #259

### DIFF
--- a/examples/standalone_lcp.cpp
+++ b/examples/standalone_lcp.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+#include <sdsl/lcp.hpp>
+#include <sdsl/suffix_arrays.hpp>
+
+using namespace std;
+using namespace sdsl;
+
+int main(int argc, char* argv[])
+{
+    if (argc < 2) {
+        cout << "Usage: " << argv[0] << " file" << endl;
+        return 1;
+    }
+    string file = argv[1];
+
+    cache_config cc(false); // do not delete temp files after csa construction
+    csa_wt<> csa;
+    construct(csa, file, 1);
+
+    cc.delete_files = true; // delete temp files after lcp construction
+    lcp_wt<> lcp;
+    construct(lcp, file, 1);
+
+    if (csa.size() < 1000) {
+        cout << csa << endl;
+        cout << "-------" << endl;
+        cout << lcp << endl;
+    }
+}

--- a/include/sdsl/io.hpp
+++ b/include/sdsl/io.hpp
@@ -767,8 +767,9 @@ bool load_from_checked_file(T& v, const std::string& file)
 
 template<class t_iv>
 inline typename std::enable_if<
-std::is_same<typename t_iv::index_category ,iv_tag>::value or
-std::is_same<typename t_iv::index_category ,csa_tag>::value
+std::is_same<typename t_iv::index_category, iv_tag>::value or
+std::is_same<typename t_iv::index_category, csa_tag>::value or
+std::is_same<typename t_iv::index_category, lcp_tag>::value
 , std::ostream&>::type
 operator<<(std::ostream& os, const t_iv& v)
 {

--- a/include/sdsl/lcp_bitcompressed.hpp
+++ b/include/sdsl/lcp_bitcompressed.hpp
@@ -44,6 +44,7 @@ class lcp_bitcompressed
         typedef ptrdiff_t                                       difference_type;
 
         typedef lcp_plain_tag                                   lcp_category;
+        typedef lcp_tag                                         index_category;
 
         enum { fast_access = 1,
                text_order  = 0,
@@ -67,7 +68,8 @@ class lcp_bitcompressed
         lcp_bitcompressed& operator=(lcp_bitcompressed&&) = default;
 
         //! Constructor taking a cache_config
-        lcp_bitcompressed(cache_config& config) {
+        lcp_bitcompressed(cache_config& config)
+        {
             std::string lcp_file = cache_file_name(conf::KEY_LCP, config);
             int_vector_buffer<> lcp_buf(lcp_file);
             m_lcp = int_vector<t_width>(lcp_buf.size(), 0, lcp_buf.width());
@@ -77,45 +79,53 @@ class lcp_bitcompressed
         }
 
         //! Number of elements in the instance.
-        size_type size()const {
+        size_type size()const
+        {
             return m_lcp.size();
         }
 
         //! Returns the largest size that lcp_bitcompressed can ever have.
-        static size_type max_size() {
+        static size_type max_size()
+        {
             return int_vector<t_width>::max_size();
         }
 
         //! Returns if the data structure is empty.
-        bool empty()const {
+        bool empty()const
+        {
             return m_lcp.empty();
         }
 
         //! Swap method for lcp_bitcompressed
-        void swap(lcp_bitcompressed& lcp_c) {
+        void swap(lcp_bitcompressed& lcp_c)
+        {
             m_lcp.swap(lcp_c.m_lcp);
         }
 
         //! Returns a const_iterator to the first element.
-        const_iterator begin()const {
+        const_iterator begin()const
+        {
             return const_iterator(this, 0);
         }
 
         //! Returns a const_iterator to the element after the last element.
-        const_iterator end()const {
+        const_iterator end()const
+        {
             return const_iterator(this, size());
         }
 
         //! Access operator
         /*! \param i Index of the value. \f$ i \in [0..size()-1]\f$.
          */
-        value_type operator[](size_type i)const {
+        value_type operator[](size_type i)const
+        {
             return m_lcp[i];
         }
 
         //! Serialize to a stream.
         size_type serialize(std::ostream& out, structure_tree_node* v=nullptr,
-                            std::string name="")const {
+                            std::string name="")const
+        {
             structure_tree_node* child = structure_tree::add_child(v, name,
                                          util::class_name(*this));
             size_type written_bytes = 0;
@@ -125,7 +135,8 @@ class lcp_bitcompressed
         }
 
         //! Load from a stream.
-        void load(std::istream& in) {
+        void load(std::istream& in)
+        {
             m_lcp.load(in);
         }
 };

--- a/include/sdsl/lcp_byte.hpp
+++ b/include/sdsl/lcp_byte.hpp
@@ -63,6 +63,7 @@ class lcp_byte
         typedef ptrdiff_t                                difference_type;
 
         typedef lcp_plain_tag                            lcp_category;
+        typedef lcp_tag                                  index_tag;
 
         enum { fast_access = 0,
                text_order  = 0,
@@ -91,7 +92,8 @@ class lcp_byte
         lcp_byte& operator=(lcp_byte&&) = default;
 
         //! Constructor
-        lcp_byte(cache_config& config) {
+        lcp_byte(cache_config& config)
+        {
             std::string lcp_file = cache_file_name(conf::KEY_LCP, config);
             int_vector_buffer<> lcp_buf(lcp_file);
             m_small_lcp = int_vector<8>(lcp_buf.size());
@@ -120,22 +122,26 @@ class lcp_byte
         }
 
         //! Number of elements in the instance.
-        size_type size()const {
+        size_type size()const
+        {
             return m_small_lcp.size();
         }
 
         //! Returns the largest size that lcp_byte can ever have.
-        static size_type max_size() {
+        static size_type max_size()
+        {
             return int_vector<8>::max_size();
         }
 
         //! Returns if the data strucutre is empty.
-        bool empty()const {
+        bool empty()const
+        {
             return m_small_lcp.empty();
         }
 
         //! Swap method for lcp_byte
-        void swap(lcp_byte& lcp_c) {
+        void swap(lcp_byte& lcp_c)
+        {
             m_small_lcp.swap(lcp_c.m_small_lcp);
             m_big_lcp.swap(lcp_c.m_big_lcp);
             m_big_lcp_idx.swap(lcp_c.m_big_lcp_idx);
@@ -143,12 +149,14 @@ class lcp_byte
 
 
         //! Returns a const_iterator to the first element.
-        const_iterator begin()const {
+        const_iterator begin()const
+        {
             return const_iterator(this, 0);
         }
 
         //! Returns a const_iterator to the element after the last element.
-        const_iterator end()const {
+        const_iterator end()const
+        {
             return const_iterator(this, size());
         }
 
@@ -156,7 +164,8 @@ class lcp_byte
         /*! \param i Index of the value. \f$ i \in [0..size()-1]\f$.
          * Time complexity: O(1) for small and O(log n) for large values
          */
-        inline value_type operator[](size_type i)const {
+        inline value_type operator[](size_type i)const
+        {
             if (m_small_lcp[i]!=255) {
                 return m_small_lcp[i];
             } else {
@@ -169,7 +178,8 @@ class lcp_byte
 
         //! Serialize to a stream.
         size_type serialize(std::ostream& out, structure_tree_node* v=nullptr,
-                            std::string name="")const {
+                            std::string name="")const
+        {
             structure_tree_node* child = structure_tree::add_child(v, name,
                                          util::class_name(*this));
             size_type written_bytes = 0;
@@ -181,7 +191,8 @@ class lcp_byte
         }
 
         //! Load from a stream.
-        void load(std::istream& in) {
+        void load(std::istream& in)
+        {
             m_small_lcp.load(in);
             m_big_lcp.load(in);
             m_big_lcp_idx.load(in);

--- a/include/sdsl/lcp_vlc.hpp
+++ b/include/sdsl/lcp_vlc.hpp
@@ -53,6 +53,7 @@ class lcp_vlc
         typedef t_vlc_vec                             vlc_vec_type;
 
         typedef lcp_plain_tag                         lcp_category;
+        typedef lcp_tag                               index_category;
 
         enum { fast_access = 0,
                text_order  = 0,
@@ -78,7 +79,8 @@ class lcp_vlc
         lcp_vlc& operator=(lcp_vlc&&) = default;
 
         //! Construct
-        lcp_vlc(cache_config& config, std::string other_key="") {
+        lcp_vlc(cache_config& config, std::string other_key="")
+        {
             std::string lcp_key  = conf::KEY_LCP;
             if ("" != other_key) {
                 lcp_key = other_key;
@@ -89,43 +91,51 @@ class lcp_vlc
         }
 
         //! Number of elements in the instance.
-        size_type size()const {
+        size_type size()const
+        {
             return m_vec.size();
         }
 
         //! Returns the largest size that lcp_vlc can ever have.
-        static size_type max_size() {
+        static size_type max_size()
+        {
             return vlc_vec_type::max_size();
         }
 
         //! Returns if the data strucutre is empty.
-        bool empty()const {
+        bool empty()const
+        {
             return m_vec.empty();
         }
 
         //! Swap method for lcp_vlc
-        void swap(lcp_vlc& lcp_c) {
+        void swap(lcp_vlc& lcp_c)
+        {
             m_vec.swap(lcp_c.m_vec);
         }
 
         //! Returns a const_iterator to the first element.
-        const_iterator begin()const {
+        const_iterator begin()const
+        {
             return const_iterator(this, 0);
         }
 
 
         //! Returns a const_iterator to the element after the last element.
-        const_iterator end()const {
+        const_iterator end()const
+        {
             return const_iterator(this, size());
         }
 
         //! []-operator
-        inline value_type operator[](size_type i)const {
+        inline value_type operator[](size_type i)const
+        {
             return m_vec[i];
         }
 
         //! Serialize to a stream.
-        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const {
+        size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const
+        {
             structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
             size_type written_bytes = 0;
             written_bytes += m_vec.serialize(out, child, "vec");
@@ -134,7 +144,8 @@ class lcp_vlc
         }
 
         //! Load from a stream.
-        void load(std::istream& in) {
+        void load(std::istream& in)
+        {
             m_vec.load(in);
         }
 };

--- a/include/sdsl/lcp_wt.hpp
+++ b/include/sdsl/lcp_wt.hpp
@@ -63,9 +63,10 @@ class lcp_wt
         typedef ptrdiff_t                                difference_type;
         typedef wt_huff<bit_vector, rank_support_v<>,
                 select_support_scan<1>,
-                select_support_scan<0>>          small_lcp_type;
+                select_support_scan<0>>                  small_lcp_type;
 
         typedef lcp_plain_tag                            lcp_category;
+        typedef lcp_tag                                  index_category;
 
         enum { fast_access = 0,
                text_order  = 0,
@@ -94,7 +95,8 @@ class lcp_wt
         lcp_wt& operator=(lcp_wt&&) = default;
 
         //! Constructor
-        lcp_wt(cache_config& config, std::string other_key="") {
+        lcp_wt(cache_config& config, std::string other_key="")
+        {
             std::string temp_file = tmp_file(config, "_lcp_sml");
             std::string lcp_key  = conf::KEY_LCP;
             if ("" != other_key) {
@@ -132,41 +134,48 @@ class lcp_wt
         }
 
         //! Number of elements in the instance.
-        size_type size()const {
+        size_type size()const
+        {
             return m_small_lcp.size();
         }
 
         //! Returns the largest size that lcp_wt can ever have.
-        static size_type max_size() {
+        static size_type max_size()
+        {
             return int_vector<8>::max_size();
         }
 
         //! Returns if the data structure is empty.
-        bool empty()const {
+        bool empty()const
+        {
             return 0==m_small_lcp.size();
         }
 
         //! Swap method for lcp_wt
-        void swap(lcp_wt& lcp_c) {
+        void swap(lcp_wt& lcp_c)
+        {
             m_small_lcp.swap(lcp_c.m_small_lcp);
             m_big_lcp.swap(lcp_c.m_big_lcp);
         }
 
         //! Returns a const_iterator to the first element.
-        const_iterator begin()const {
+        const_iterator begin()const
+        {
             return const_iterator(this, 0);
         }
 
 
         //! Returns a const_iterator to the element after the last element.
-        const_iterator end()const {
+        const_iterator end()const
+        {
             return const_iterator(this, size());
         }
 
         //! []-operator
         /*! \param i Index of the value. \f$ i \in [0..size()-1]\f$.
          */
-        inline value_type operator[](size_type i)const {
+        inline value_type operator[](size_type i)const
+        {
             if (m_small_lcp[i]!=255) {
                 return m_small_lcp[i];
             } else {
@@ -176,7 +185,8 @@ class lcp_wt
 
         //! Serialize to a stream.
         size_type serialize(std::ostream& out, structure_tree_node* v=nullptr,
-                            std::string name="")const {
+                            std::string name="")const
+        {
             structure_tree_node* child = structure_tree::add_child(
                                              v, name, util::class_name(*this));
             size_type written_bytes = 0;
@@ -187,7 +197,8 @@ class lcp_wt
         }
 
         //! Load from a stream.
-        void load(std::istream& in) {
+        void load(std::istream& in)
+        {
             m_small_lcp.load(in);
             m_big_lcp.load(in);
         }


### PR DESCRIPTION
Added construction method for standalone compressed LCP representations.
See examples/standalone_lcp.cpp for an example.