### PR TITLE
Fix issue #309. 

### DIFF
--- a/include/sdsl/wt_helper.hpp
+++ b/include/sdsl/wt_helper.hpp
@@ -8,6 +8,7 @@
 #include <queue>
 #include <vector>
 #include <utility>
+#include <array>
 
 namespace sdsl
 {


### PR DESCRIPTION
Added missing include for std::array in wt_helper.hpp.
Thanks @le-van for the fix.