### PR TITLE
WT node access, rank and select

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Requirements
 
 The SDSL library requires:
 
-* A modern, C++11 ready compiler such as `g++` version 4.7 or higher or `clang` version 3.2 or higher.
+* A modern, C++11 ready compiler such as `g++` version 4.9 or higher or `clang` version 3.2 or higher.
 * The [cmake][cmake] build system.
 * A 64-bit operating system. Either Mac OS X or Linux are currently supported.
 * For increased performance the processor of the system should support fast bit operations available in `SSE4.2`


### PR DESCRIPTION
Provides functions to access, rank, and select bits over a WT node (only certain kinds).

These are still only hand-tested, but at least they won't break any current functionality, and someone might find them useful, so I figured I should issue a pull request now.

(It's also my first non-trivial pull request, so I wanted to try it out).