### PR TITLE
sd_vector_builder now works for all sd_vector configurations

### DIFF
--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -275,8 +275,8 @@ class sd_vector
             m_wl = builder.m_wl;
             m_low.swap(builder.m_low);
             util::assign(m_high, builder.m_high);
-            util::init_support(m_high_1_select, this->m_high);
-            util::init_support(m_high_0_select, this->m_high);
+            util::init_support(m_high_1_select, &(this->m_high));
+            util::init_support(m_high_0_select, &(this->m_high));
 
             builder = sd_vector_builder();
         }

--- a/test/bit_vector_test.cpp
+++ b/test/bit_vector_test.cpp
@@ -29,7 +29,7 @@ rrr_vector<192>,
 rrr_vector<255>,
 rrr_vector<15>,
 rrr_vector<31>,
-rrr_vector
+rrr_vector<63>,
 rrr_vector<83>,
 rrr_vector<127>,
 rrr_vector<128>,

--- a/test/bit_vector_test.cpp
+++ b/test/bit_vector_test.cpp
@@ -29,7 +29,7 @@ rrr_vector<192>,
 rrr_vector<255>,
 rrr_vector<15>,
 rrr_vector<31>,
-rrr_vector<63>,
+rrr_vector
 rrr_vector<83>,
 rrr_vector<127>,
 rrr_vector<128>,
@@ -108,27 +108,6 @@ TYPED_TEST(bit_vector_test, swap)
         ASSERT_EQ((bool)(bv[j]), (bool)(bv_empty[j]));
     }
 }
-
-/*
-TEST(SD_VECTOR, IteratorConstructor)
-{
-    std::vector<uint64_t> pos;
-    bit_vector bv(100000);
-    std::mt19937_64 rng;
-    std::uniform_int_distribution<uint64_t> distribution(0, 9);
-    auto dice = bind(distribution, rng);
-    for (size_t i=0; i < bv.size(); ++i) {
-        if (0 == dice()) {
-            pos.emplace_back(i);
-            bv[i] = 1;
-        }
-    }
-    sd_vector<> sdv(pos.begin(),pos.end());
-    for (size_t i=0; i < bv.size(); ++i) {
-        ASSERT_EQ((bool)sdv[i],(bool)bv[i]);
-    }
-}
-*/
 
 }// end namespace
 

--- a/test/sd_vector_test.cpp
+++ b/test/sd_vector_test.cpp
@@ -1,4 +1,5 @@
 #include "sdsl/sd_vector.hpp"
+#include "sdsl/bit_vectors.hpp"
 #include "gtest/gtest.h"
 
 using namespace sdsl;
@@ -9,7 +10,19 @@ namespace
 
 const size_t BV_SIZE = 1000000;
 
-TEST(sd_vector_test, iterator_constructor)
+template<class T>
+class sd_vector_test : public ::testing::Test { };
+
+using testing::Types;
+
+typedef Types<
+sd_vector<>,
+          sd_vector<rrr_vector<63>>
+          > Implementations;
+
+TYPED_TEST_CASE(sd_vector_test, Implementations);
+
+TYPED_TEST(sd_vector_test, iterator_constructor)
 {
     std::vector<uint64_t> pos;
     bit_vector bv(BV_SIZE);
@@ -22,13 +35,13 @@ TEST(sd_vector_test, iterator_constructor)
             bv[i] = 1;
         }
     }
-    sd_vector<> sdv(pos.begin(),pos.end());
+    TypeParam sdv(pos.begin(),pos.end());
     for (size_t i=0; i < bv.size(); ++i) {
         ASSERT_EQ((bool)sdv[i],(bool)bv[i]);
     }
 }
 
-TEST(sd_vector_test, builder_constructor)
+TYPED_TEST(sd_vector_test, builder_constructor)
 {
     std::vector<uint64_t> pos;
     bit_vector bv(BV_SIZE);
@@ -47,18 +60,18 @@ TEST(sd_vector_test, builder_constructor)
     for (auto i : pos) {
         builder.set(i);
     }
-    sd_vector<> sdv(builder);
+    TypeParam sdv(builder);
     for (size_t i=0; i < bv.size(); ++i) {
         ASSERT_EQ((bool)sdv[i],(bool)bv[i]);
     }
 }
 
-TEST(sd_vector_test, builder_empty_constructor)
+TYPED_TEST(sd_vector_test, builder_empty_constructor)
 {
     sd_vector_builder builder(BV_SIZE, 0UL);
-    sd_vector<> sdv(builder);
+    TypeParam sdv(builder);
     for (size_t i=0; i < BV_SIZE; ++i) {
-        ASSERT_EQ(0, sdv[i]);
+        ASSERT_FALSE((bool)sdv[i]);
     }
 }
 


### PR DESCRIPTION
sd_vector_builder was just working for sd_vector<bit_vector,....>.
This is fix now. Also adjusted tests.