### PR TITLE
Move global debug variable from header to source file

### DIFF
--- a/include/sdsl/hyb_sd_vector.hpp
+++ b/include/sdsl/hyb_sd_vector.hpp
@@ -33,7 +33,7 @@ namespace sdsl
 {
 
 //std::vector<uint64_t> g_range_stats;
-size_t g_saved_bits=0;
+extern size_t g_saved_bits;
 
 template <class t_itr>
 std::string print_vec(t_itr beg, t_itr end)

--- a/lib/hyb_sd_vector.cpp
+++ b/lib/hyb_sd_vector.cpp
@@ -1,0 +1,4 @@
+#include "sdsl/hyb_sd_vector.hpp"
+namespace sdsl {
+  size_t g_saved_bits = 0;
+}


### PR DESCRIPTION
To temporarily fix a compile error in surf-offset.