### PR TITLE
make wt_int and wm_int thread safe

### DIFF
--- a/include/sdsl/wm_int.hpp
+++ b/include/sdsl/wm_int.hpp
@@ -95,8 +95,6 @@ class wm_int
         uint32_t               m_max_level = 0;
         int_vector<64>         m_zero_cnt;     // m_zero_cnt[i] contains the number of zeros in level i
         int_vector<64>         m_rank_level;   // m_rank_level[i] contains m_tree_rank(i*size())
-        mutable int_vector<64> m_path_off;     // array keeps track of path offset in select-like methods
-        mutable int_vector<64> m_path_rank_off;// array keeps track of rank values for the offsets
 
         void copy(const wm_int& wt)
         {
@@ -112,16 +110,6 @@ class wm_int
             m_max_level     = wt.m_max_level;
             m_zero_cnt      = wt.m_zero_cnt;
             m_rank_level    = wt.m_rank_level;
-            m_path_off      = wt.m_path_off;
-            m_path_rank_off = wt.m_path_rank_off;
-        }
-
-    private:
-
-        void init_buffers(uint32_t max_level)
-        {
-            m_path_off = int_vector<64>(max_level+1);
-            m_path_rank_off = int_vector<64>(max_level+1);
         }
 
     public:
@@ -133,7 +121,6 @@ class wm_int
         //! Default constructor
         wm_int()
         {
-            init_buffers(m_max_level);
         };
 
         //! Semi-external constructor
@@ -150,7 +137,6 @@ class wm_int
         wm_int(int_vector_buffer<int_width>& buf, size_type size,
                uint32_t max_level=0) : m_size(size)
         {
-            init_buffers(m_max_level);
             if (0 == m_size)
                 return;
             size_type n = buf.size();  // set n
@@ -174,7 +160,6 @@ class wm_int
             } else {
                 m_max_level = max_level;
             }
-            init_buffers(m_max_level);
 
 
             std::string tree_out_buf_file_name = tmp_file(buf.filename(), "_m_tree");
@@ -271,8 +256,6 @@ class wm_int
                 m_max_level     = std::move(wt.m_max_level);
                 m_zero_cnt      = std::move(wt.m_zero_cnt);
                 m_rank_level    = std::move(wt.m_rank_level);
-                m_path_off      = std::move(wt.m_path_off);
-                m_path_rank_off = std::move(wt.m_path_rank_off);
             }
             return *this;
         }
@@ -290,8 +273,6 @@ class wm_int
                 std::swap(m_max_level,  wt.m_max_level);
                 m_zero_cnt.swap(wt.m_zero_cnt);
                 m_rank_level.swap(wt.m_rank_level);
-                m_path_off.swap(wt.m_path_off);
-                m_path_rank_off.swap(wt.m_path_rank_off);
             }
         }
 
@@ -410,6 +391,8 @@ class wm_int
         {
             assert(1 <= i and i <= rank(size(), c));
             uint64_t mask = 1ULL << (m_max_level-1);
+            int_vector<64> m_path_off(max_level+1);
+            int_vector<64> m_path_rank_off(max_level+1);
             m_path_off[0] = m_path_rank_off[0] = 0;
             size_type b = 0; // start position of the interval
             size_type r = i;
@@ -565,7 +548,6 @@ class wm_int
             read_member(m_max_level, in);
             m_zero_cnt.load(in);
             m_rank_level.load(in);
-            init_buffers(m_max_level);
         }
 
         //! Represents a node in the wavelet tree

--- a/include/sdsl/wt_int.hpp
+++ b/include/sdsl/wt_int.hpp
@@ -88,8 +88,6 @@ class wt_int
         select_1_type          m_tree_select1; // select support for the wavelet tree bit vector
         select_0_type          m_tree_select0;
         uint32_t               m_max_level = 0;
-        mutable int_vector<64> m_path_off;     // array keeps track of path offset in select-like methods
-        mutable int_vector<64> m_path_rank_off;// array keeps track of rank values for the offsets
 
         void copy(const wt_int& wt) {
             m_size          = wt.m_size;
@@ -102,16 +100,9 @@ class wt_int
             m_tree_select0  = wt.m_tree_select0;
             m_tree_select0.set_vector(&m_tree);
             m_max_level     = wt.m_max_level;
-            m_path_off      = wt.m_path_off;
-            m_path_rank_off = wt.m_path_rank_off;
         }
 
     private:
-
-        void init_buffers(uint32_t max_level) {
-            m_path_off = int_vector<64>(max_level+1);
-            m_path_rank_off = int_vector<64>(max_level+1);
-        }
 
         // recursive internal version of the method interval_symbols
         void _interval_symbols(size_type i, size_type j, size_type& k,
@@ -163,7 +154,6 @@ class wt_int
 
         //! Default constructor
         wt_int() {
-            init_buffers(m_max_level);
         };
 
         //! Semi-external constructor
@@ -179,7 +169,6 @@ class wt_int
         template<uint8_t int_width>
         wt_int(int_vector_buffer<int_width>& buf, size_type size,
                uint32_t max_level=0) : m_size(size) {
-            init_buffers(m_max_level);
             if (0 == m_size)
                 return;
             size_type n = buf.size();  // set n
@@ -202,7 +191,6 @@ class wt_int
             } else {
                 m_max_level = max_level;
             }
-            init_buffers(m_max_level);
 
             // buffer for elements in the right node
             int_vector_buffer<> buf1(tmp_file(buf.filename(), "_wt_constr_buf"),
@@ -298,8 +286,6 @@ class wt_int
                 m_tree_select0  = std::move(wt.m_tree_select0);
                 m_tree_select0.set_vector(&m_tree);
                 m_max_level     = std::move(wt.m_max_level);
-                m_path_off      = std::move(wt.m_path_off);
-                m_path_rank_off = std::move(wt.m_path_rank_off);
             }
             return *this;
         }
@@ -314,8 +300,6 @@ class wt_int
                 util::swap_support(m_tree_select1, wt.m_tree_select1, &m_tree, &(wt.m_tree));
                 util::swap_support(m_tree_select0, wt.m_tree_select0, &m_tree, &(wt.m_tree));
                 std::swap(m_max_level,  wt.m_max_level);
-                m_path_off.swap(wt.m_path_off);
-                m_path_rank_off.swap(wt.m_path_rank_off);
             }
         }
 
@@ -444,6 +428,8 @@ class wt_int
             size_type offset = 0;
             uint64_t mask    = (1ULL) << (m_max_level-1);
             size_type node_size = m_size;
+            int_vector<64> m_path_off(max_level+1);
+            int_vector<64> m_path_rank_off(max_level+1);
             m_path_off[0] = m_path_rank_off[0] = 0;
 
             for (uint32_t k=0; k < m_max_level and node_size; ++k) {
@@ -727,7 +713,6 @@ class wt_int
             m_tree_select1.load(in, &m_tree);
             m_tree_select0.load(in, &m_tree);
             read_member(m_max_level, in);
-            init_buffers(m_max_level);
         }
 
         //! Represents a node in the wavelet tree


### PR DESCRIPTION
Moves m_path_off and m_path_rank_off into select function in both wm_int and wt_int. As a result they are allocated for every call to select, which could harm performance. Alternatives include passing a per-thread buffer into each select call.

This is relevant to #263.