### PR TITLE
added bitwise &=, |=, and ^= operators for uncompressed bitvectors

### DIFF
--- a/include/sdsl/int_vector.hpp
+++ b/include/sdsl/int_vector.hpp
@@ -541,6 +541,15 @@ class int_vector
         //! Greater of equal operator
         bool operator>=(const int_vector& v) const;
 
+        //! bitwise-and-update operator
+        int_vector& operator&=(const int_vector& v);
+
+        //! bitwise-or-update equal operator
+        int_vector& operator|=(const int_vector& v);
+
+        //! bitwise-xor-update operator
+        int_vector& operator^=(const int_vector& v);
+
         //! Iterator that points to the first element of the int_vector.
         /*!  Time complexity guaranty is O(1).
          */
@@ -1501,6 +1510,36 @@ template<uint8_t t_width>
 bool int_vector<t_width>::operator!=(const int_vector& v)const
 {
     return !(*this==v);
+}
+
+template<uint8_t t_width>
+int_vector<t_width>& int_vector<t_width>::operator&=(const int_vector& v)
+{
+    assert(bit_size() == v.bit_size());
+    assert(v.capacity() <= capacity());
+    for (uint64_t i=0; i<(v.capacity()>>6); ++i)
+        m_data[i] &= v.m_data[i];
+    return *this;
+}
+
+template<uint8_t t_width>
+int_vector<t_width>& int_vector<t_width>::operator|=(const int_vector& v)
+{
+    assert(bit_size() == v.bit_size());
+    assert(v.capacity() <= capacity());
+    for (uint64_t i=0; i<(v.capacity()>>6); ++i)
+        m_data[i] |= v.m_data[i];
+    return *this;
+}
+
+template<uint8_t t_width>
+int_vector<t_width>& int_vector<t_width>::operator^=(const int_vector& v)
+{
+    assert(bit_size() == v.bit_size());
+    assert(v.capacity() <= capacity());
+    for (uint64_t i=0; i<(v.capacity()>>6); ++i)
+        m_data[i] ^= v.m_data[i];
+    return *this;
 }
 
 template<uint8_t t_width>

--- a/test/bit_vector_test.cpp
+++ b/test/bit_vector_test.cpp
@@ -109,6 +109,87 @@ TYPED_TEST(bit_vector_test, swap)
     }
 }
 
+TYPED_TEST(bit_vector_test, and_with)
+{
+    bit_vector bv1(10000, 0);
+    bit_vector bv2(10000, 0);
+    uint32_t lfsr1 = 0x0000A8ED;
+    uint32_t lfsr2 = 0x00000001;
+    for (size_t i=0; i < bv1.size(); ++i) {
+        lfsr1 = (lfsr1 >> 1) ^ ((lfsr1&1)*0x00013013);  // period  8463
+        lfsr2 = (lfsr2 >> 1) ^ ((lfsr2&1)*0x0004FA4B);  // period 81915
+        bv1[i] = lfsr1&1;
+        bv2[i] = lfsr2&1;
+    }
+
+    bv1 &= bv2;
+
+    lfsr1 = 0x0000A8ED;
+    lfsr2 = 0x00000001;
+    for (size_t i=0; i < bv1.size(); ++i) {
+        lfsr1 = (lfsr1 >> 1) ^ ((lfsr1&1)*0x00013013);
+        lfsr2 = (lfsr2 >> 1) ^ ((lfsr2&1)*0x0004FA4B);
+        ASSERT_EQ(bv1[i], (lfsr1&1) & (lfsr2&1))
+                << "i="<<i<<endl;
+        ASSERT_EQ(bv2[i], lfsr2&1)
+                << "i="<<i<<endl;
+    }
+}
+
+TYPED_TEST(bit_vector_test, or_with)
+{
+    bit_vector bv1(10000, 0);
+    bit_vector bv2(10000, 0);
+    uint32_t lfsr1 = 0x0000A8ED;
+    uint32_t lfsr2 = 0x00000001;
+    for (size_t i=0; i < bv1.size(); ++i) {
+        lfsr1 = (lfsr1 >> 1) ^ ((lfsr1&1)*0x00013013);  // period  8463
+        lfsr2 = (lfsr2 >> 1) ^ ((lfsr2&1)*0x0004FA4B);  // period 81915
+        bv1[i] = lfsr1&1;
+        bv2[i] = lfsr2&1;
+    }
+
+    bv1 |= bv2;
+
+    lfsr1 = 0x0000A8ED;
+    lfsr2 = 0x00000001;
+    for (size_t i=0; i < bv1.size(); ++i) {
+        lfsr1 = (lfsr1 >> 1) ^ ((lfsr1&1)*0x00013013);
+        lfsr2 = (lfsr2 >> 1) ^ ((lfsr2&1)*0x0004FA4B);
+        ASSERT_EQ(bv1[i], (lfsr1&1) | (lfsr2&1))
+                << "i="<<i<<endl;
+        ASSERT_EQ(bv2[i], lfsr2&1)
+                << "i="<<i<<endl;
+    }
+}
+
+TYPED_TEST(bit_vector_test, xor_with)
+{
+    bit_vector bv1(10000, 0);
+    bit_vector bv2(10000, 0);
+    uint32_t lfsr1 = 0x0000A8ED;
+    uint32_t lfsr2 = 0x00000001;
+    for (size_t i=0; i < bv1.size(); ++i) {
+        lfsr1 = (lfsr1 >> 1) ^ ((lfsr1&1)*0x00013013);  // period  8463
+        lfsr2 = (lfsr2 >> 1) ^ ((lfsr2&1)*0x0004FA4B);  // period 81915
+        bv1[i] = lfsr1&1;
+        bv2[i] = lfsr2&1;
+    }
+
+    bv1 ^= bv2;
+
+    lfsr1 = 0x0000A8ED;
+    lfsr2 = 0x00000001;
+    for (size_t i=0; i < bv1.size(); ++i) {
+        lfsr1 = (lfsr1 >> 1) ^ ((lfsr1&1)*0x00013013);
+        lfsr2 = (lfsr2 >> 1) ^ ((lfsr2&1)*0x0004FA4B);
+        ASSERT_EQ(bv1[i], (lfsr1&1) ^ (lfsr2&1))
+                << "i="<<i<<endl;
+        ASSERT_EQ(bv2[i], lfsr2&1)
+                << "i="<<i<<endl;
+    }
+}
+
 }// end namespace
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
Relating to issue #355.  Added the three operators and a unit test for each.