### PR TITLE
Add pkg-config definition for sdsl-lite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,4 +139,9 @@ ADD_CUSTOM_TARGET(uninstall-sdsl
 
 target_include_directories(sdsl PUBLIC include)
 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/sdsl-lite.pc.cmake"
+               "${CMAKE_CURRENT_BINARY_DIR}/sdsl-lite.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sdsl-lite.pc"
+        DESTINATION "lib/pkgconfig")
+
 add_subdirectory(test)

--- a/sdsl-lite.pc.cmake
+++ b/sdsl-lite.pc.cmake
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION_FULL@
+URL: @PROJECT_URL@
+Libs: -L${libdir} -lsdsl -ldivsufsort -ldivsufsort64
+Cflags: -I${includedir}

--- a/sdsl-lite.pc.cmake
+++ b/sdsl-lite.pc.cmake
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/lib
+includedir=${prefix}/include
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@


### PR DESCRIPTION
Hi,

This adds a pkg-config definition for sdsl-lite, enabling projects that use `pkg-config` for module discovery to find an install of `sdsl-lite`, and use the correct libraries.

Cheers,
Kevin