### PR TITLE
Add level ancestor to bp_support_sada

### DIFF
--- a/include/sdsl/bp_support_sada.hpp
+++ b/include/sdsl/bp_support_sada.hpp
@@ -212,6 +212,21 @@ class bp_support_sada
             std::cout<< std::endl;
         }
 
+	//! Returns the level ancestor of the node i.
+	/*! \param i The index of a parenthesis (i.e., a node).
+	 *  \param d The level, i.e., which node to select on the path from the node i up to the root. 
+	 *           The level d = 0 will return the node itself, d = 1 will return its parent, and so on.
+	 */
+        size_type level_anc(size_type i, size_type d)const
+        {
+            assert(i < m_size);
+            size_type bwd_ex = bwd_excess(i,-d-1);
+            if (bwd_ex == size())
+                return size();
+            else
+                return bwd_ex+1;
+        }
+
         //! Calculate the min parenthesis \f$j>i\f$ with \f$excess(j)=excess(i)+rel\f$
         /*! \param i   The index of a parenthesis in the supported sequence.
          *  \param rel The excess difference to the excess value of parentheses \f$i\f$.

--- a/include/sdsl/bp_support_sada.hpp
+++ b/include/sdsl/bp_support_sada.hpp
@@ -212,20 +212,6 @@ class bp_support_sada
             std::cout<< std::endl;
         }
 
-	//! Returns the level ancestor of the node i.
-	/*! \param i The index of a parenthesis (i.e., a node).
-	 *  \param d The level, i.e., which node to select on the path from the node i up to the root. 
-	 *           The level d = 0 will return the node itself, d = 1 will return its parent, and so on.
-	 */
-        size_type level_anc(size_type i, size_type d)const
-        {
-            assert(i < m_size);
-            size_type bwd_ex = bwd_excess(i,-d-1);
-            if (bwd_ex == size())
-                return size();
-            else
-                return bwd_ex+1;
-        }
 
         //! Calculate the min parenthesis \f$j>i\f$ with \f$excess(j)=excess(i)+rel\f$
         /*! \param i   The index of a parenthesis in the supported sequence.
@@ -892,7 +878,22 @@ class bp_support_sada
             }
         }
 
-        /*! The size of the supported balanced parentheses sequence.
+		//! Returns the level ancestor of the node i.
+		/*! \param i The index of a parenthesis (i.e., a node).
+		 *  \param d The level, i.e., which node to select on the path from the node i up to the root. 
+		 *           The level d = 0 will return the node itself, d = 1 will return its parent, and so on.
+		 */
+		size_type level_anc(size_type i, size_type d)const
+		{
+			assert(i < m_size);
+			size_type bwd_ex = bwd_excess(i,-d-1);
+			if (bwd_ex == size())
+				return size();
+			else
+				return bwd_ex+1;
+		}
+
+		/*! The size of the supported balanced parentheses sequence.
          * \return the size of the supported balanced parentheses sequence.
          */
         size_type size() const

--- a/test/cst_byte_test.cpp
+++ b/test/cst_byte_test.cpp
@@ -45,6 +45,29 @@ cst_sct3<>,
          cst_sct3<csa_bitcompressed<>, lcp_bitcompressed<> >
          > Implementations;
 
+
+template<class T>
+class cst_byte_test_sada : public ::testing::Test { };
+typedef Types<cst_sada<>> sadaBPImpl;
+TYPED_TEST_CASE(cst_byte_test_sada, sadaBPImpl);
+TYPED_TEST(cst_byte_test_sada, create_and_store)
+{
+    TypeParam cst;
+	typedef typename TypeParam::node_type node_t;
+    ASSERT_TRUE(load_from_file(cst, temp_file));
+	for(const node_t& node : cst) {
+		node_t ancestor = node;
+		size_t level = 0;
+		while(ancestor != cst.root()) {
+			const node_t bpa = cst.bp_support.level_anc(node, level);
+			ASSERT_EQ(bpa, ancestor);
+			ancestor = cst.parent(ancestor);
+			++level;
+		}
+	}
+}
+
+
 TYPED_TEST_CASE(cst_byte_test, Implementations);
 
 


### PR DESCRIPTION
I added a level ancestor method to bp_sada.
Since I think that it is useful, I want to contribute this small code snippet.