### PR TITLE
Fixed a few missing std:: in examples/storage-visualization.cpp.

### DIFF
--- a/examples/storage-visualization.cpp
+++ b/examples/storage-visualization.cpp
@@ -10,15 +10,15 @@ using namespace sdsl;
 int main(int argc, char** argv)
 {
     if (argc < 2) {
-        cout << "Usage: " << argv[0] << " file" << std::endl;
-        cout << " Creates a CST for a byte file and visualizes the space used by the data structure." << std::endl;
-        return 1;
+      std::cout << "Usage: " << argv[0] << " file" << std::endl;
+      std::cout << " Creates a CST for a byte file and visualizes the space used by the data structure." << std::endl;
+      return 1;
     }
     cst_sct3<> cst;
     auto start = timer::now();
-    cout << "constructing cst..." << std::endl;
+    std::cout << "constructing cst..." << std::endl;
     construct(cst, argv[1], 1);
-    cout << "construction cst time in seconds: " << duration_cast<seconds>(timer::now()-start).count() << std::endl;
+    std::cout << "construction cst time in seconds: " << duration_cast<seconds>(timer::now()-start).count() << std::endl;
 
     std::ofstream ofs("cst-space-usage.html");
     std::cout << "writing storage visualization to cst-space-usage.html" << std::endl;


### PR DESCRIPTION
There are a few std:: missing in front of cout in examples/storage-visualization.cpp.