### PR TITLE
Removed warning for address never null

### DIFF
--- a/include/sdsl/io.hpp
+++ b/include/sdsl/io.hpp
@@ -635,8 +635,6 @@ bool store_to_cache(const T& v, const std::string& key, cache_config& config, bo
 template<class T>
 typename T::size_type size_in_bytes(const T& t)
 {
-    if ((&t) == nullptr)
-        return 0;
     nullstream ns;
     return serialize(t, ns);
 }


### PR DESCRIPTION
Compiling the code with GCC 6.1 I get the following error:
```cpp
sdsl-lite/build/lib/../include/sdsl/io.hpp:638:14: warning: the compiler can assume that the address of 't' will never be NULL [-Waddress]
     if ((&t) == nullptr)
         ~~~~~^~~~~~~
```