### PR TITLE
Add default ctor in random_access_const_iterator

### DIFF
--- a/include/sdsl/iterators.hpp
+++ b/include/sdsl/iterators.hpp
@@ -48,6 +48,10 @@ class random_access_const_iterator: public std::iterator<std::random_access_iter
 
 
     public:
+
+        //! Default Constructor
+        random_access_const_iterator() : m_rac(nullptr), m_idx(0) { }
+
         //! Constructor
         random_access_const_iterator(const t_rac* rac, size_type idx = 0) : m_rac(rac), m_idx(idx) { }
 


### PR DESCRIPTION
Added missing default ctor in sdsl::random_access_const_iterator, which prevents other classes with sdsl::random_access_const_iterator member fields to have an implicitly-declared default constructor.