### PR TITLE
Improve DAC vector performance by using plain bit vectors by default

### DIFF
--- a/include/sdsl/dac_vector.hpp
+++ b/include/sdsl/dac_vector.hpp
@@ -39,12 +39,12 @@ namespace sdsl
  *       [1] N. Brisaboa and S. Ladra and G. Navarro: ,,DACs: Bringing Direct Access to Variable-Length Codes'',
              Information Processing and Management (IPM) 2013
  *
- * \tparam t_default_max_levels    Maximum number of levels to use.
  * \tparam t_bv                    Bit vector to use for overflow bits. Use
  *                                 rrr_vector<> for maximum compression, and
- *                                 bit_vector for speed
+ *                                 bit_vector for speed.
+ * \tparam t_default_max_levels    Maximum number of levels to use.
  */
-template <int t_default_max_levels = 64, typename t_bv=bit_vector>
+template <typename t_bv = bit_vector, int t_default_max_levels = 64>
 class dac_vector_dp
 {
         static_assert(t_default_max_levels > 0, "invalid max level count");

--- a/include/sdsl/lcp_dac.hpp
+++ b/include/sdsl/lcp_dac.hpp
@@ -38,8 +38,8 @@ template<uint8_t  t_b    = 4,
          typename t_rank = rank_support_v5<>>
 using lcp_dac = lcp_vlc<dac_vector<t_b, t_rank>>;
 
-template<int t_default_max_levels    = 64>
-using lcp_dac_dp = lcp_vlc<dac_vector_dp<t_default_max_levels>>;
+template<typename t_bv = bit_vector, int t_default_max_levels = 64>
+using lcp_dac_dp = lcp_vlc<dac_vector_dp<t_bv, t_default_max_levels>>;
 
 } // end namespace sdsl
 #endif

--- a/test/dac_vector_test.cpp
+++ b/test/dac_vector_test.cpp
@@ -156,24 +156,32 @@ TEST(DacVectorTest, LargeRandomBench) {
 
         sdsl::dac_vector<> v1(vec);
         sdsl::dac_vector_dp<> v2(vec);
+        sdsl::dac_vector_dp<sdsl::rrr_vector<>> v3(vec);
 
         std::cout << "benchmark size " << sz << std::endl;
         std::cout << "  dac_vector levels    " << v1.levels() << std::endl;
         std::cout << "  dac_vector_dp levels " << v2.levels() << std::endl;
 
         size_t s1=0;
-        std::cout << "  time dac_vector    " << measure([&]() {
+        std::cout << "  time dac_vector                  " << measure([&]() {
             for (size_t query : query_indexes)
                 s1+=v1[query];
         }) << std::endl;
 
         size_t s2=0;
-        std::cout << "  time dac_vector_dp " << measure([&]() {
+        std::cout << "  time dac_vector_dp               " << measure([&]() {
             for (size_t query : query_indexes)
                 s2+=v2[query];
         }) << std::endl;
 
+        size_t s3=0;
+        std::cout << "  time dac_vector_dp<rrr_vector<>> " << measure([&]() {
+            for (size_t query : query_indexes)
+                s3+=v3[query];
+        }) << std::endl;
+
         ASSERT_EQ(s1, s2);
+        ASSERT_EQ(s1, s3);
     }
 }
 

--- a/test/dac_vector_test.cpp
+++ b/test/dac_vector_test.cpp
@@ -55,7 +55,7 @@ void run_test(const std::vector<value_type>& vec) {
     }
 
     for (int max_levels = 1; max_levels <= 32; max_levels *= 2) {
-        sdsl::dac_vector_dp<64, sdsl::rrr_vector<>> v(vec, max_levels);
+        sdsl::dac_vector_dp<sdsl::rrr_vector<>> v(vec, max_levels);
         if (v.levels() == last_levels)
             break;
         last_levels = v.levels();
@@ -64,7 +64,7 @@ void run_test(const std::vector<value_type>& vec) {
         v.serialize(ss);
         std::cout << "  new (rrr) with " << v.levels() << " levels = "
             << ss.str().size() << std::endl;
-        sdsl::dac_vector_dp<64, sdsl::rrr_vector<>> w;
+        sdsl::dac_vector_dp<sdsl::rrr_vector<>> w;
         w.load(ss);
         for (size_t i = 0; i < vec.size(); ++i)
             ASSERT_EQ(vec[i], w[i]);


### PR DESCRIPTION
The old version (which compresses slightly better) can still be chosen by using `dac_vector_dp<rrr_vector<>>`. The new version uses plain bit vectors, which has vastly superior query times. Example run:

These are the resulting data structure sizes:

random exponential test 9
  old = 303961
  new (plain) with 1 levels = 290689
  new (plain) with 2 levels = 261706
  new (plain) with 4 levels = 257820
  new (rrr) with 1 levels = 276308
  new (rrr) with 2 levels = 252565
  new (rrr) with 4 levels = 250591


These are timings:

benchmark size 10000
  dac_vector levels    6
  dac_vector_dp levels 4
  time dac_vector                  6746
  time dac_vector_dp               2049
  time dac_vector_dp<rrr_vector<>> 64340
benchmark size 100000
  dac_vector levels    6
  dac_vector_dp levels 4
  time dac_vector                  7959
  time dac_vector_dp               2178
  time dac_vector_dp<rrr_vector<>> 66496
benchmark size 1000000
  dac_vector levels    6
  dac_vector_dp levels 4
  time dac_vector                  10827
  time dac_vector_dp               3274
  time dac_vector_dp<rrr_vector<>> 65654
benchmark size 10000000
  dac_vector levels    6
  dac_vector_dp levels 5
  time dac_vector                  31223
  time dac_vector_dp               6775
  time dac_vector_dp<rrr_vector<>> 86530
