### PR TITLE
doc: fix usage of install script when prefix is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ home directory. A different location prefix can be specified as a parameter of
 the `install.sh` script:
 
 ```sh
-./install /usr/local/
+./install.sh /usr/local/
 ```
 
 To remove the library from your system use the provided uninstall script:


### PR DESCRIPTION
This PR is a minor documentation fix for the `./install.sh` usage (when a prefix is set).