### PR TITLE
Update googletest submodule url 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/googletest"]
 	path = external/googletest
-	url = https://chromium.googlesource.com/external/googletest
+	url = https://github.com/google/googletest.git
 [submodule "external/libdivsufsort"]
 	path = external/libdivsufsort
 	url = https://github.com/simongog/libdivsufsort.git

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -13,7 +13,7 @@ set(BUILD_DIVSUFSORT64 ON CACHE BOOL "Build libdivsufsort in 64-bits mode")
 
 add_subdirectory(libdivsufsort)
 
-## Add gtest 
+## Add gtest
 set(gtest_dir ${CMAKE_CURRENT_LIST_DIR}/googletest)
 set(gtest_file ${gtest_dir}/CMakeLists.txt)
 if(NOT EXISTS ${gtest_file})
@@ -23,6 +23,6 @@ if(NOT EXISTS ${gtest_file})
             )
 endif(NOT EXISTS ${gtest_file})
 
-add_subdirectory(googletest)
+add_subdirectory(googletest/googletest)
 
-   
+


### PR DESCRIPTION
Google has depricated the old googltest git url so this PR changes the url to the new github based googletest url.

@rsharris can you checkout this branch and make sure that this now works properly (also run make test-sdsl in the build directory to see if gtest gets compiled properly)