### PR TITLE
optionally build without sse4.2 on a system that supports sse4.2

### DIFF
--- a/CMakeModules/CheckSSE4_2.cmake
+++ b/CMakeModules/CheckSSE4_2.cmake
@@ -2,8 +2,10 @@
 # for popcount, leftmost and rightmost bit
 
 set(BUILTIN_POPCNT 0)
+if(DEFINED ENV{NO_SSE42})
+	#message(STATUS "sse4.2 disabled")
 # Check if we are on a Linux system
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	# Use /proc/cpuinfo to get the information
 	file(STRINGS "/proc/cpuinfo" _cpuinfo)
 	if(_cpuinfo MATCHES "(sse4_2)|(sse4a)")

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ the `install.sh` script:
 ./install.sh /usr/local/
 ```
 
+To build a portable sdsl library without dependency on the `SSE4.2` instruction set `NO_SSE42` at build time, e.g. `NO_SSE42=1 ./install.sh` or `mkdir build && NO_SSE42=1 cmake ..`.
+`SSE4.2` instructions are enabled by default if the processor of the build system supports it.
+
 To remove the library from your system use the provided uninstall script:
 
 ```sh


### PR DESCRIPTION
This allows the user to disable sse4.2 by setting NO_SSE42=1 when calling cmake. This allows building portable executables using sdsl-lite even on systems that might have the sse4.2 instructions.

For instance you can do this to build without the sse4.2 dependent code:

```
cd $(SDSL_DIR) && NO_SSE42=1 ./install.sh $(CWD)
```