### PR TITLE
Initialize bt_array to correct size in rrr_vector constructor

### DIFF
--- a/include/sdsl/memory_management.hpp
+++ b/include/sdsl/memory_management.hpp
@@ -323,7 +323,11 @@ class memory_manager
                 return (uint64_t*)hugepage_allocator::the_allocator().mm_realloc(ptr, size);
             }
 #endif
-            return (uint64_t*)realloc(ptr, size);
+            uint64_t* temp = (uint64_t*)realloc(ptr, size);
+            if (temp == NULL) {
+                throw std::bad_alloc();
+            }
+            return temp;
         }
     public:
         static void use_hugepages(size_t bytes = 0)

--- a/include/sdsl/rrr_vector.hpp
+++ b/include/sdsl/rrr_vector.hpp
@@ -145,9 +145,10 @@ class rrr_vector
         rrr_vector(const bit_vector& bv)
         {
             m_size = bv.size();
-            int_vector<> bt_array;
-            bt_array.width(bits::hi(t_bs)+1);
-            bt_array.resize((m_size+t_bs)/((size_type)t_bs)); // blocks for the bt_array + a dummy block at the end,
+            int_vector<> bt_array((m_size+t_bs)/((size_type)t_bs), 0, bits::hi(t_bs)+1);
+            //int_vector<> bt_array;
+            //bt_array.width(bits::hi(t_bs)+1);
+            //bt_array.resize((m_size+t_bs)/((size_type)t_bs)); // blocks for the bt_array + a dummy block at the end,
             // if m_size%t_bs == 0
 
             // (1) calculate the block types and store them in m_bt


### PR DESCRIPTION
Initializing bt_array, then resizing it can potentially create a null pointer if realloc in memory_management.hpp fails.

If realloc fails in memory_management.hpp, throw std::bad_alloc()