### PR TITLE
Fixing function operator[] in dac_vector

### DIFF
--- a/include/sdsl/dac_vector.hpp
+++ b/include/sdsl/dac_vector.hpp
@@ -457,13 +457,13 @@ class dac_vector
         {
             uint8_t level = 1;
             uint8_t offset = t_b;
-            size_type result = m_data[i];
+            value_type result = m_data[i];
             const uint64_t* p = m_level_pointer_and_rank.data();
             uint64_t ppi = (*p)+i;
             while (level < m_max_level and m_overflow[ppi]) {
                 p += 2;
                 ppi = *p + (m_overflow_rank(ppi) - *(p-1));
-                result |= (m_data[ppi] << (offset));
+                result |= ((value_type) m_data[ppi] << (offset));
                 ++level;
                 offset += t_b;
             }


### PR DESCRIPTION
When I tried to retrieve the value 2147483649 from a dac_vector<16>, I obtained the value 18446744071562067969. However, with a dac_vector<7>, it works. 

The mistake is in operator[], when the shift offset is executed, a cast to value_type is needed.

This is my code:

`
#include <sdsl/dac_vector.hpp>
#include <vector>

int main()
{

	std::vector<uint64_t> values = {2147483649};	
	sdsl::dac_vector<16> dac_16(values);
	std::cout << dac_16[0] << std::endl;
	sdsl::dac_vector<7> dac_7(values);
	std::cout << dac_7[0] << std::endl;
}
`