### PR TITLE
Default to a verbose install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ if [ $? != 0 ]; then
 	exit 1
 fi
 
-cmake -DCMAKE_INSTALL_PREFIX="${SDSL_INSTALL_PREFIX}" .. # run cmake 
+cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INSTALL_PREFIX="${SDSL_INSTALL_PREFIX}" .. # run cmake 
 if [ $? != 0 ]; then
 	echo "ERROR: CMake build failed."
 	exit 1


### PR DESCRIPTION
This would be appreciated by Debian and other software packagers who monitor for the correct inclusion of build hardening flags using https://ruderich.org/simon/blhc/

Thanks!