### PR TITLE
range_search_2d is faster now for counting queries

### DIFF
--- a/include/sdsl/wt_int.hpp
+++ b/include/sdsl/wt_int.hpp
@@ -651,6 +651,13 @@ class wt_int
             size_type irb = ilb + (1ULL << (m_max_level-level));
             size_type mid = (irb + ilb)>>1;
 
+			// the current range is [ilb,irb); thus, if it is entirely within the query range
+			// *and* no reporting is needed, we can simply take all the items and return
+			if ( not report and (vlb <= ilb and irb-1 <= vrb) ) {
+				cnt_answers+= (rb-lb+1);
+				return ;
+			}
+
             size_type offset = offsets[level];
 
             size_type ones_before_o    = m_tree_rank(offset);


### PR DESCRIPTION
When the weight range [a,b] is entirely within the query range [p,q], it is not necessary to go all the way down to $\lg{\sigma}$ levels inside `_range_search_2d` -- the 3-line additional check speeds up counting (of course, not reporting -- for reporting we need to recover the weights bottom-up) queries few times, on reasonably large datasets.