### PR TITLE
use wstring as input to stoull to make GCC 10.1.0 happy

### DIFF
--- a/lib/io.cpp
+++ b/lib/io.cpp
@@ -82,7 +82,7 @@ uint64_t _parse_number(std::string::const_iterator& c, const std::string::const_
     std::string::const_iterator s = c;
     while (c != end and isdigit(*c)) ++c;
     if (c > s) {
-        return std::stoull(std::string(s,c));
+        return std::stoull(std::wstring(s,c));
     } else {
         return 0;
     }


### PR DESCRIPTION
I ran into a change in GCC behavior in 10.1.0.

Apparently, it's not possible to apply `std::stoull` to a regular `std::string`, and now `std::wstring` is required.

For instance

```c++
#include <iostream>
#include <string>                                                                                                                                                                               

uint64_t _parse_number(std::string::const_iterator& c, const std::string::const_iterator& end) {
    std::string::const_iterator s = c;
    while (c != end and isdigit(*c)) ++c;
    if (c > s) {
        return std::stoull(std::string(s,c));
    } else {
        return 0;                                                                                                                                                                                  
    }
}

int main(int argc, char** argv) {
    std::string s(argv[1]);
    std::string::const_iterator b = s.begin();
    std::string::const_iterator e = s.end();
    std::cout << _parse_number(b, e) << std::endl;
    return 0;
}
```

Compiling with GCC 10.1.0 gives this error:

```
-> % g++ test-stoull.cpp -o test-stoull
test-stoull.cpp: In function ‘uint64_t _parse_number(std::__cxx11::basic_string<char>::const_iterator&, const const_iterator&)’:                                                               test-stoull.cpp:13:33: error: invalid initialization of reference of type ‘const wstring&’ {aka ‘const std::__cxx11::basic_string<wchar_t>&’} from expression of type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
   13 |         return std::stoull(std::string(s,c));
      |                                 ^~~~~~~~~~~
In file included from /home/erikg/.guix-profile/include/c++/string:55,
                 from /home/erikg/.guix-profile/include/c++/bits/locale_classes.h:40,
                 from /home/erikg/.guix-profile/include/c++/bits/ios_base.h:41,
                 from /home/erikg/.guix-profile/include/c++/ios:42,
                 from /home/erikg/.guix-profile/include/c++/ostream:38,
                 from /home/erikg/.guix-profile/include/c++/iostream:39,
                 from test-stoull.cpp:1:
/home/erikg/.guix-profile/include/c++/bits/basic_string.h:6697:25: note: in passing argument 1 of ‘long long unsigned int std::__cxx11::stoull(const wstring&, std::size_t*, int)’
 6697 |   stoull(const wstring& __str, size_t* __idx = 0, int __base = 10)
      |          ~~~~~~~~~~~~~~~^~~~~
```

I get the same error when trying to compile sdsl-lite in this environment.

Changing the `_parse_number` code to use `std::wstring` resolves the issue. It might be less efficient, but I would expect things to work as before without issue. This patch does that within the io code.

I would be happy to hear that someone else can reproduce this. I didn't find much about wstring in the GCC release notes, and my environment is kind of funny (guix install).