### PR TITLE
Updating the HTTPS protocol on link

### DIFF
--- a/benchmark/k2_trees/test_case.config
+++ b/benchmark/k2_trees/test_case.config
@@ -4,4 +4,4 @@
 # (3) LaTeX name
 # (4) Download link (if the test is available online)
 EXAMPLE;../data/example_arcs;examples;http://webdatacommons.org/hyperlinkgraph/data/example_arcs
-HOSTGRAPH;../data/hostgraph.arc;hostgraph;http://users.dcc.uchile.cl/~fmontoto/static/hostgraph.arc.gz
+HOSTGRAPH;../data/hostgraph.arc;hostgraph;https://users.dcc.uchile.cl/~fmontoto/static/hostgraph.arc.gz


### PR DESCRIPTION
Failure detected in the "make timing" command: there was a recent change in the protocol on the server that hosts the hostgraph.arc file.
P.S .: test_case.config returned an .html file instead of the requested .gz, generating an unpacking error.