### PR TITLE
Fix benchmarking of rrr_vector

### DIFF
--- a/benchmark/rrr_vector/test_case.config
+++ b/benchmark/rrr_vector/test_case.config
@@ -4,7 +4,7 @@
 # (3) LaTeX name
 # (4) Download link (if not generated automatically, like rnd_X.Y)
 RND50-16M;../data/rnd_50.16MB;rnd-50.16M;
-WT-DNA-16MB;../data/WT-DNA-16MB;wt-dna.16M;http://people.eng.unimelb.edu.au/sgog/data/WT-DNA-16MB.gz
-WT-WEB-16MB;../data/WT-WEB-16MB;wt-web.16M;http://people.eng.unimelb.edu.au/sgog/data/WT-WEB-16MB.gz
-WT-DNA-1GB;../data/WT-DNA-1GB;wt-dna.1G;http://people.eng.unimelb.edu.au/sgog/data/WT-DNA-1GB.gz
-WT-WEB-1GB;../data/WT-WEB-1GB;wt-web.1G;http://people.eng.unimelb.edu.au/sgog/data/WT-WEB-1GB.gz
+WT-DNA-16MB;../data/WT-DNA-16MB;wt-dna.16M;https://people.eng.unimelb.edu.au/sgog/data/WT-DNA-16MB.gz
+WT-WEB-16MB;../data/WT-WEB-16MB;wt-web.16M;https://people.eng.unimelb.edu.au/sgog/data/WT-WEB-16MB.gz
+WT-DNA-1GB;../data/WT-DNA-1GB;wt-dna.1G;https://people.eng.unimelb.edu.au/sgog/data/WT-DNA-1GB.gz
+WT-WEB-1GB;../data/WT-WEB-1GB;wt-web.1G;https://people.eng.unimelb.edu.au/sgog/data/WT-WEB-1GB.gz

--- a/benchmark/rrr_vector/visualize/rrr.R
+++ b/benchmark/rrr_vector/visualize/rrr.R
@@ -112,7 +112,7 @@ for ( compile_id in compile_config[["COMPILE_ID"]] ){
                Compile options:
                \\texttt{",gsub("_","\\\\_",compile_config[compile_id, "OPTIONS"]),"}.
                }
-              \\end{figure}")
+              \\end{figure}", sep="")
 }
 
 # Handle space
@@ -143,7 +143,7 @@ dev.off()
 tex_doc <- paste(tex_doc,"\\begin{figure}
                  \\input{",fig_name,"}
                  \\caption{Space of \\texttt{rrr\\_vector} dependent on block size K.}.
-                 \\end{figure}")
+                 \\end{figure}", sep="")
 
 
 tex_doc <- paste(tex_doc, readLines("rrr-footer.tex"),collapse="\n")


### PR DESCRIPTION
No changes in functionality. This change fixes bad links in `test_case.config` and path errors created from additional space in `rrr.R`.